### PR TITLE
feat: implement Home Screen with full Clean Architecture

### DIFF
--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -7,6 +7,10 @@ import '../../features/auth/data/repositories/auth_repository_impl.dart';
 import '../../features/auth/domain/repositories/auth_repository.dart';
 import '../../features/auth/presentation/cubit/auth_cubit.dart';
 import '../../features/auth/presentation/cubit/password_reset_cubit.dart';
+import '../../features/home/data/datasources/home_mock_datasource.dart';
+import '../../features/home/data/repositories/home_repository_impl.dart';
+import '../../features/home/domain/repositories/home_repository.dart';
+import '../../features/home/presentation/cubit/home_cubit.dart';
 
 final getIt = GetIt.instance;
 
@@ -35,5 +39,16 @@ Future<void> configureDependencies() async {
   );
   getIt.registerFactory<PasswordResetCubit>(
     () => PasswordResetCubit(getIt<AuthRepository>()),
+  );
+
+  // Home
+  getIt.registerLazySingleton<HomeMockDatasource>(
+    () => HomeMockDatasource(),
+  );
+  getIt.registerLazySingleton<HomeRepository>(
+    () => HomeRepositoryImpl(getIt<HomeMockDatasource>()),
+  );
+  getIt.registerFactory<HomeCubit>(
+    () => HomeCubit(getIt<HomeRepository>()),
   );
 }

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import '../di/injection.dart';
+import '../../features/home/presentation/cubit/home_cubit.dart';
 import '../../features/auth/presentation/screens/splash_screen.dart';
 import '../../features/auth/presentation/screens/sign_in_screen.dart';
 import '../../features/auth/presentation/screens/sign_up_screen.dart';
@@ -83,8 +86,11 @@ class AppRouter {
         routes: [
           GoRoute(
             path: '/home',
-            pageBuilder: (context, state) => const NoTransitionPage(
-              child: HomeScreen(),
+            pageBuilder: (context, state) => NoTransitionPage(
+              child: BlocProvider(
+                create: (_) => getIt<HomeCubit>()..loadHome(),
+                child: const HomeScreen(),
+              ),
             ),
           ),
           GoRoute(

--- a/lib/features/home/data/datasources/home_mock_datasource.dart
+++ b/lib/features/home/data/datasources/home_mock_datasource.dart
@@ -1,0 +1,197 @@
+import '../models/banner_model.dart';
+import '../models/category_model.dart';
+import '../models/product_model.dart';
+
+class HomeMockDatasource {
+  Future<List<BannerModel>> getBanners() async {
+    await Future.delayed(const Duration(milliseconds: 800));
+    return const [
+      BannerModel(
+        id: '1',
+        imageUrl: 'https://via.placeholder.com/400x200/4CAF50/FFFFFF?text=Fresh+African+Groceries',
+        title: 'Fresh African Groceries',
+        subtitle: 'Up to 30% off on first order',
+      ),
+      BannerModel(
+        id: '2',
+        imageUrl: 'https://via.placeholder.com/400x200/2E7D32/FFFFFF?text=Free+Delivery',
+        title: 'Free Delivery',
+        subtitle: 'On orders above \$50',
+      ),
+      BannerModel(
+        id: '3',
+        imageUrl: 'https://via.placeholder.com/400x200/FFC107/212121?text=Weekend+Special',
+        title: 'Weekend Special',
+        subtitle: 'Buy 2 Get 1 Free',
+      ),
+    ];
+  }
+
+  Future<List<CategoryModel>> getCategories() async {
+    await Future.delayed(const Duration(milliseconds: 600));
+    return const [
+      CategoryModel(id: '1', name: 'Grocery'),
+      CategoryModel(id: '2', name: 'Meats'),
+      CategoryModel(id: '3', name: 'Fish'),
+      CategoryModel(id: '4', name: 'Drinks'),
+      CategoryModel(id: '5', name: 'Bakery'),
+      CategoryModel(id: '6', name: 'Fruits'),
+      CategoryModel(id: '7', name: 'Poultry'),
+      CategoryModel(id: '8', name: 'Others'),
+      CategoryModel(id: '9', name: 'African'),
+    ];
+  }
+
+  Future<List<ProductModel>> getFeaturedProducts() async {
+    await Future.delayed(const Duration(milliseconds: 700));
+    return const [
+      ProductModel(
+        id: '1',
+        name: 'Sunflower Oil',
+        imageUrl: 'https://via.placeholder.com/300x300/FFF9C4/212121?text=Sunflower+Oil',
+        price: 59.00,
+        originalPrice: 75.00,
+        rating: 4.5,
+        reviewCount: 120,
+        discountPercent: 21,
+        unit: '1L',
+      ),
+      ProductModel(
+        id: '2',
+        name: 'Chicken Sharma',
+        imageUrl: 'https://via.placeholder.com/300x300/FFCCBC/212121?text=Chicken+Sharma',
+        price: 140.00,
+        originalPrice: 160.00,
+        rating: 4.8,
+        reviewCount: 89,
+        discountPercent: 12,
+        unit: '1kg',
+      ),
+      ProductModel(
+        id: '3',
+        name: 'Fresh Tilapia',
+        imageUrl: 'https://via.placeholder.com/300x300/B3E5FC/212121?text=Fresh+Tilapia',
+        price: 95.00,
+        originalPrice: 120.00,
+        rating: 4.3,
+        reviewCount: 67,
+        discountPercent: 20,
+        unit: '1kg',
+      ),
+      ProductModel(
+        id: '4',
+        name: 'Jollof Rice Mix',
+        imageUrl: 'https://via.placeholder.com/300x300/FFECB3/212121?text=Jollof+Rice',
+        price: 25.00,
+        rating: 4.7,
+        reviewCount: 203,
+        unit: '500g',
+      ),
+      ProductModel(
+        id: '5',
+        name: 'Palm Oil',
+        imageUrl: 'https://via.placeholder.com/300x300/FFE0B2/212121?text=Palm+Oil',
+        price: 45.00,
+        originalPrice: 55.00,
+        rating: 4.6,
+        reviewCount: 156,
+        discountPercent: 18,
+        unit: '1L',
+      ),
+    ];
+  }
+
+  Future<List<ProductModel>> getBestSelling() async {
+    await Future.delayed(const Duration(milliseconds: 700));
+    return const [
+      ProductModel(
+        id: '6',
+        name: 'Cassava Flour',
+        imageUrl: 'https://via.placeholder.com/300x300/FFF9C4/212121?text=Cassava+Flour',
+        price: 18.00,
+        originalPrice: 22.00,
+        rating: 4.4,
+        reviewCount: 312,
+        discountPercent: 18,
+        unit: '1kg',
+      ),
+      ProductModel(
+        id: '7',
+        name: 'Egusi Seeds',
+        imageUrl: 'https://via.placeholder.com/300x300/C8E6C9/212121?text=Egusi+Seeds',
+        price: 32.00,
+        rating: 4.6,
+        reviewCount: 245,
+        unit: '500g',
+      ),
+      ProductModel(
+        id: '8',
+        name: 'Plantain Chips',
+        imageUrl: 'https://via.placeholder.com/300x300/FFE0B2/212121?text=Plantain+Chips',
+        price: 12.00,
+        originalPrice: 15.00,
+        rating: 4.2,
+        reviewCount: 189,
+        discountPercent: 20,
+        unit: '200g',
+      ),
+      ProductModel(
+        id: '9',
+        name: 'Dried Stockfish',
+        imageUrl: 'https://via.placeholder.com/300x300/FFCCBC/212121?text=Dried+Stockfish',
+        price: 85.00,
+        originalPrice: 100.00,
+        rating: 4.7,
+        reviewCount: 134,
+        discountPercent: 15,
+        unit: '500g',
+      ),
+    ];
+  }
+
+  Future<List<ProductModel>> getPopularProducts() async {
+    await Future.delayed(const Duration(milliseconds: 700));
+    return const [
+      ProductModel(
+        id: '10',
+        name: 'Suya Spice Mix',
+        imageUrl: 'https://via.placeholder.com/300x300/FFCCBC/212121?text=Suya+Spice',
+        price: 15.00,
+        rating: 4.8,
+        reviewCount: 420,
+        unit: '200g',
+      ),
+      ProductModel(
+        id: '11',
+        name: 'Shea Butter',
+        imageUrl: 'https://via.placeholder.com/300x300/FFF9C4/212121?text=Shea+Butter',
+        price: 28.00,
+        originalPrice: 35.00,
+        rating: 4.5,
+        reviewCount: 276,
+        discountPercent: 20,
+        unit: '250g',
+      ),
+      ProductModel(
+        id: '12',
+        name: 'Yam Flour (Poundo)',
+        imageUrl: 'https://via.placeholder.com/300x300/C8E6C9/212121?text=Yam+Flour',
+        price: 22.00,
+        rating: 4.3,
+        reviewCount: 198,
+        unit: '1kg',
+      ),
+      ProductModel(
+        id: '13',
+        name: 'Groundnut Paste',
+        imageUrl: 'https://via.placeholder.com/300x300/FFE0B2/212121?text=Groundnut+Paste',
+        price: 19.00,
+        originalPrice: 24.00,
+        rating: 4.4,
+        reviewCount: 167,
+        discountPercent: 20,
+        unit: '500g',
+      ),
+    ];
+  }
+}

--- a/lib/features/home/data/datasources/home_remote_datasource.dart
+++ b/lib/features/home/data/datasources/home_remote_datasource.dart
@@ -1,0 +1,77 @@
+import 'package:dio/dio.dart';
+import '../../../../core/api/api_exceptions.dart';
+import '../../../../core/constants/api_endpoints.dart';
+import '../models/banner_model.dart';
+import '../models/category_model.dart';
+import '../models/product_model.dart';
+
+class HomeRemoteDatasource {
+  final Dio _dio;
+
+  HomeRemoteDatasource(this._dio);
+
+  Future<List<BannerModel>> getBanners() async {
+    try {
+      final response = await _dio.get(ApiEndpoints.banners);
+      final data = response.data as Map<String, dynamic>;
+      final list = data['data'] as List<dynamic>? ?? [];
+      return list
+          .map((e) => BannerModel.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+
+  Future<List<CategoryModel>> getCategories() async {
+    try {
+      final response = await _dio.get(ApiEndpoints.homeCategories);
+      final data = response.data as Map<String, dynamic>;
+      final list = data['data'] as List<dynamic>? ?? [];
+      return list
+          .map((e) => CategoryModel.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+
+  Future<List<ProductModel>> getFeaturedProducts() async {
+    try {
+      final response = await _dio.get(ApiEndpoints.featuredProducts);
+      final data = response.data as Map<String, dynamic>;
+      final list = data['data'] as List<dynamic>? ?? [];
+      return list
+          .map((e) => ProductModel.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+
+  Future<List<ProductModel>> getBestSelling() async {
+    try {
+      final response = await _dio.get(ApiEndpoints.bestSelling);
+      final data = response.data as Map<String, dynamic>;
+      final list = data['data'] as List<dynamic>? ?? [];
+      return list
+          .map((e) => ProductModel.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+
+  Future<List<ProductModel>> getPopularProducts() async {
+    try {
+      final response = await _dio.get(ApiEndpoints.popularProducts);
+      final data = response.data as Map<String, dynamic>;
+      final list = data['data'] as List<dynamic>? ?? [];
+      return list
+          .map((e) => ProductModel.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+}

--- a/lib/features/home/data/models/banner_model.dart
+++ b/lib/features/home/data/models/banner_model.dart
@@ -1,0 +1,25 @@
+class BannerModel {
+  final String id;
+  final String imageUrl;
+  final String? title;
+  final String? subtitle;
+  final String? actionUrl;
+
+  const BannerModel({
+    required this.id,
+    required this.imageUrl,
+    this.title,
+    this.subtitle,
+    this.actionUrl,
+  });
+
+  factory BannerModel.fromJson(Map<String, dynamic> json) {
+    return BannerModel(
+      id: json['id']?.toString() ?? '',
+      imageUrl: json['image_url'] as String? ?? '',
+      title: json['title'] as String?,
+      subtitle: json['subtitle'] as String?,
+      actionUrl: json['action_url'] as String?,
+    );
+  }
+}

--- a/lib/features/home/data/models/category_model.dart
+++ b/lib/features/home/data/models/category_model.dart
@@ -1,0 +1,22 @@
+class CategoryModel {
+  final String id;
+  final String name;
+  final String? imageUrl;
+  final String? iconUrl;
+
+  const CategoryModel({
+    required this.id,
+    required this.name,
+    this.imageUrl,
+    this.iconUrl,
+  });
+
+  factory CategoryModel.fromJson(Map<String, dynamic> json) {
+    return CategoryModel(
+      id: json['id']?.toString() ?? '',
+      name: json['name'] as String? ?? '',
+      imageUrl: json['image_url'] as String?,
+      iconUrl: json['icon_url'] as String?,
+    );
+  }
+}

--- a/lib/features/home/data/models/product_model.dart
+++ b/lib/features/home/data/models/product_model.dart
@@ -1,0 +1,40 @@
+class ProductModel {
+  final String id;
+  final String name;
+  final String imageUrl;
+  final double price;
+  final double? originalPrice;
+  final double? rating;
+  final int? reviewCount;
+  final int? discountPercent;
+  final String? unit;
+  final String? storeName;
+
+  const ProductModel({
+    required this.id,
+    required this.name,
+    required this.imageUrl,
+    required this.price,
+    this.originalPrice,
+    this.rating,
+    this.reviewCount,
+    this.discountPercent,
+    this.unit,
+    this.storeName,
+  });
+
+  factory ProductModel.fromJson(Map<String, dynamic> json) {
+    return ProductModel(
+      id: json['id']?.toString() ?? '',
+      name: json['name'] as String? ?? '',
+      imageUrl: json['image_url'] as String? ?? '',
+      price: (json['price'] as num?)?.toDouble() ?? 0,
+      originalPrice: (json['original_price'] as num?)?.toDouble(),
+      rating: (json['rating'] as num?)?.toDouble(),
+      reviewCount: json['review_count'] as int?,
+      discountPercent: json['discount_percent'] as int?,
+      unit: json['unit'] as String?,
+      storeName: json['store_name'] as String?,
+    );
+  }
+}

--- a/lib/features/home/data/repositories/home_repository_impl.dart
+++ b/lib/features/home/data/repositories/home_repository_impl.dart
@@ -1,0 +1,63 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/api/api_exceptions.dart';
+import '../../domain/repositories/home_repository.dart';
+import '../datasources/home_mock_datasource.dart';
+import '../models/banner_model.dart';
+import '../models/category_model.dart';
+import '../models/product_model.dart';
+
+class HomeRepositoryImpl implements HomeRepository {
+  final HomeMockDatasource _mockDatasource;
+
+  HomeRepositoryImpl(this._mockDatasource);
+
+  @override
+  Future<Either<ApiException, List<BannerModel>>> getBanners() async {
+    try {
+      final banners = await _mockDatasource.getBanners();
+      return Right(banners);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+
+  @override
+  Future<Either<ApiException, List<CategoryModel>>> getCategories() async {
+    try {
+      final categories = await _mockDatasource.getCategories();
+      return Right(categories);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+
+  @override
+  Future<Either<ApiException, List<ProductModel>>> getFeaturedProducts() async {
+    try {
+      final products = await _mockDatasource.getFeaturedProducts();
+      return Right(products);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+
+  @override
+  Future<Either<ApiException, List<ProductModel>>> getBestSelling() async {
+    try {
+      final products = await _mockDatasource.getBestSelling();
+      return Right(products);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+
+  @override
+  Future<Either<ApiException, List<ProductModel>>> getPopularProducts() async {
+    try {
+      final products = await _mockDatasource.getPopularProducts();
+      return Right(products);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+}

--- a/lib/features/home/domain/repositories/home_repository.dart
+++ b/lib/features/home/domain/repositories/home_repository.dart
@@ -1,0 +1,13 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/api/api_exceptions.dart';
+import '../../data/models/banner_model.dart';
+import '../../data/models/category_model.dart';
+import '../../data/models/product_model.dart';
+
+abstract class HomeRepository {
+  Future<Either<ApiException, List<BannerModel>>> getBanners();
+  Future<Either<ApiException, List<CategoryModel>>> getCategories();
+  Future<Either<ApiException, List<ProductModel>>> getFeaturedProducts();
+  Future<Either<ApiException, List<ProductModel>>> getBestSelling();
+  Future<Either<ApiException, List<ProductModel>>> getPopularProducts();
+}

--- a/lib/features/home/presentation/cubit/home_cubit.dart
+++ b/lib/features/home/presentation/cubit/home_cubit.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../data/models/banner_model.dart';
+import '../../data/models/category_model.dart';
+import '../../data/models/product_model.dart';
+import '../../domain/repositories/home_repository.dart';
+import 'home_state.dart';
+
+class HomeCubit extends Cubit<HomeState> {
+  final HomeRepository _homeRepository;
+
+  HomeCubit(this._homeRepository) : super(const HomeState());
+
+  Future<void> loadHome() async {
+    emit(state.copyWith(status: HomeStatus.loading));
+
+    final results = await Future.wait([
+      _homeRepository.getBanners(),
+      _homeRepository.getCategories(),
+      _homeRepository.getFeaturedProducts(),
+      _homeRepository.getBestSelling(),
+      _homeRepository.getPopularProducts(),
+    ]);
+
+    String? error;
+
+    results[0].fold(
+      (e) => error = e.message,
+      (data) => emit(state.copyWith(
+        banners: List<BannerModel>.from(data),
+      )),
+    );
+    results[1].fold(
+      (e) => error = e.message,
+      (data) => emit(state.copyWith(
+        categories: List<CategoryModel>.from(data),
+      )),
+    );
+    results[2].fold(
+      (e) => error = e.message,
+      (data) => emit(state.copyWith(
+        featuredProducts: List<ProductModel>.from(data),
+      )),
+    );
+    results[3].fold(
+      (e) => error = e.message,
+      (data) => emit(state.copyWith(
+        bestSelling: List<ProductModel>.from(data),
+      )),
+    );
+    results[4].fold(
+      (e) => error = e.message,
+      (data) => emit(state.copyWith(
+        popularProducts: List<ProductModel>.from(data),
+      )),
+    );
+
+    if (error != null) {
+      emit(state.copyWith(status: HomeStatus.error, errorMessage: error));
+    } else {
+      emit(state.copyWith(status: HomeStatus.loaded));
+    }
+  }
+
+  Future<void> refresh() async {
+    await loadHome();
+  }
+}

--- a/lib/features/home/presentation/cubit/home_state.dart
+++ b/lib/features/home/presentation/cubit/home_state.dart
@@ -1,0 +1,45 @@
+import '../../data/models/banner_model.dart';
+import '../../data/models/category_model.dart';
+import '../../data/models/product_model.dart';
+
+enum HomeStatus { initial, loading, loaded, error }
+
+class HomeState {
+  final HomeStatus status;
+  final List<BannerModel> banners;
+  final List<CategoryModel> categories;
+  final List<ProductModel> featuredProducts;
+  final List<ProductModel> bestSelling;
+  final List<ProductModel> popularProducts;
+  final String? errorMessage;
+
+  const HomeState({
+    this.status = HomeStatus.initial,
+    this.banners = const [],
+    this.categories = const [],
+    this.featuredProducts = const [],
+    this.bestSelling = const [],
+    this.popularProducts = const [],
+    this.errorMessage,
+  });
+
+  HomeState copyWith({
+    HomeStatus? status,
+    List<BannerModel>? banners,
+    List<CategoryModel>? categories,
+    List<ProductModel>? featuredProducts,
+    List<ProductModel>? bestSelling,
+    List<ProductModel>? popularProducts,
+    String? errorMessage,
+  }) {
+    return HomeState(
+      status: status ?? this.status,
+      banners: banners ?? this.banners,
+      categories: categories ?? this.categories,
+      featuredProducts: featuredProducts ?? this.featuredProducts,
+      bestSelling: bestSelling ?? this.bestSelling,
+      popularProducts: popularProducts ?? this.popularProducts,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+}

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -1,6 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import '../../../../core/constants/app_colors.dart';
 import '../../../../core/constants/app_strings.dart';
+import '../../../../core/widgets/product_card.dart';
+import '../../data/models/product_model.dart';
+import '../cubit/home_cubit.dart';
+import '../cubit/home_state.dart';
+import '../widgets/banner_carousel.dart';
+import '../widgets/category_scroll.dart';
+import '../widgets/home_shimmer.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -9,131 +18,162 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       body: SafeArea(
-        child: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Top bar
-              Padding(
-                padding: const EdgeInsets.all(16),
-                child: Row(
+        child: BlocBuilder<HomeCubit, HomeState>(
+          builder: (context, state) {
+            if (state.status == HomeStatus.loading ||
+                state.status == HomeStatus.initial) {
+              return const HomeShimmer();
+            }
+
+            if (state.status == HomeStatus.error &&
+                state.banners.isEmpty) {
+              return _ErrorView(
+                message: state.errorMessage ?? 'Something went wrong',
+                onRetry: () => context.read<HomeCubit>().loadHome(),
+              );
+            }
+
+            return RefreshIndicator(
+              color: AppColors.primary,
+              onRefresh: () => context.read<HomeCubit>().refresh(),
+              child: SingleChildScrollView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text('Deliver to', style: Theme.of(context).textTheme.bodySmall),
-                          const Row(
-                            children: [
-                              Icon(Icons.location_on, size: 16, color: AppColors.primary),
-                              SizedBox(width: 4),
-                              Text(
-                                'San Francisco, CA',
-                                style: TextStyle(fontWeight: FontWeight.w600, fontSize: 14),
-                              ),
-                              Icon(Icons.keyboard_arrow_down, size: 20),
-                            ],
-                          ),
-                        ],
-                      ),
+                    _buildTopBar(context),
+                    _buildSearchBar(context),
+                    const SizedBox(height: 20),
+                    BannerCarousel(banners: state.banners),
+                    const SizedBox(height: 20),
+                    _buildSectionHeader(
+                      context,
+                      AppStrings.categories,
+                      () => context.push('/categories'),
                     ),
-                    IconButton(
-                      onPressed: () {},
-                      icon: const Badge(
-                        smallSize: 8,
-                        child: Icon(Icons.notifications_outlined),
-                      ),
+                    const SizedBox(height: 12),
+                    CategoryScroll(
+                      categories: state.categories,
+                      onCategoryTap: (category) {
+                        context.push(
+                          '/products/${category.id}',
+                          extra: category.name,
+                        );
+                      },
                     ),
+                    const SizedBox(height: 20),
+                    _buildSectionHeader(
+                      context,
+                      AppStrings.featuredProducts,
+                      () {},
+                    ),
+                    const SizedBox(height: 12),
+                    _buildHorizontalProductList(
+                      context,
+                      state.featuredProducts,
+                    ),
+                    const SizedBox(height: 20),
+                    _buildSectionHeader(
+                      context,
+                      AppStrings.bestSelling,
+                      () {},
+                    ),
+                    const SizedBox(height: 12),
+                    _buildProductGrid(context, state.bestSelling),
+                    const SizedBox(height: 20),
+                    _buildSectionHeader(
+                      context,
+                      AppStrings.popularProducts,
+                      () {},
+                    ),
+                    const SizedBox(height: 12),
+                    _buildProductGrid(context, state.popularProducts),
+                    const SizedBox(height: 24),
                   ],
                 ),
               ),
-              // Search bar
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-                  decoration: BoxDecoration(
-                    color: AppColors.surface,
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                  child: const Row(
-                    children: [
-                      Icon(Icons.search, color: AppColors.textHint, size: 20),
-                      SizedBox(width: 8),
-                      Text(
-                        AppStrings.searchHint,
-                        style: TextStyle(color: AppColors.textHint, fontSize: 14),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTopBar(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Deliver to',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+                const Row(
+                  children: [
+                    Icon(Icons.location_on, size: 16, color: AppColors.primary),
+                    SizedBox(width: 4),
+                    Text(
+                      'San Francisco, CA',
+                      style: TextStyle(
+                        fontWeight: FontWeight.w600,
+                        fontSize: 14,
                       ),
-                    ],
-                  ),
+                    ),
+                    Icon(Icons.keyboard_arrow_down, size: 20),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            onPressed: () {},
+            icon: const Badge(
+              smallSize: 8,
+              child: Icon(Icons.notifications_outlined),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSearchBar(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: GestureDetector(
+        onTap: () => context.push('/search'),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          decoration: BoxDecoration(
+            color: AppColors.surface,
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Row(
+            children: [
+              const Icon(Icons.search, color: AppColors.textHint, size: 20),
+              const SizedBox(width: 8),
+              const Expanded(
+                child: Text(
+                  AppStrings.searchHint,
+                  style: TextStyle(color: AppColors.textHint, fontSize: 14),
                 ),
               ),
-              const SizedBox(height: 20),
-              // Banner placeholder
               Container(
-                height: 160,
-                margin: const EdgeInsets.symmetric(horizontal: 16),
+                padding: const EdgeInsets.all(6),
                 decoration: BoxDecoration(
-                  color: AppColors.primaryLight,
-                  borderRadius: BorderRadius.circular(16),
+                  color: AppColors.primary,
+                  borderRadius: BorderRadius.circular(8),
                 ),
-                child: const Center(
-                  child: Text(
-                    'Promotional Banner',
-                    style: TextStyle(color: AppColors.primaryDark, fontWeight: FontWeight.w600),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 20),
-              // Categories
-              _buildSectionHeader(context, 'Categories', () {}),
-              const SizedBox(height: 12),
-              SizedBox(
-                height: 90,
-                child: ListView(
-                  scrollDirection: Axis.horizontal,
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  children: const [
-                    _CategoryChip(name: 'Groceries'),
-                    _CategoryChip(name: 'Meats'),
-                    _CategoryChip(name: 'Fish'),
-                    _CategoryChip(name: 'Drinks'),
-                    _CategoryChip(name: 'Frozen'),
-                    _CategoryChip(name: 'Dairy'),
-                  ],
+                child: const Icon(
+                  Icons.tune,
+                  color: AppColors.white,
+                  size: 16,
                 ),
               ),
-              const SizedBox(height: 20),
-              _buildSectionHeader(context, AppStrings.featuredProducts, () {}),
-              const SizedBox(height: 12),
-              SizedBox(
-                height: 220,
-                child: ListView.builder(
-                  scrollDirection: Axis.horizontal,
-                  padding: const EdgeInsets.symmetric(horizontal: 16),
-                  itemCount: 5,
-                  itemBuilder: (_, i) => _buildProductPlaceholder(),
-                ),
-              ),
-              const SizedBox(height: 20),
-              _buildSectionHeader(context, AppStrings.bestSelling, () {}),
-              const SizedBox(height: 12),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: GridView.builder(
-                  shrinkWrap: true,
-                  physics: const NeverScrollableScrollPhysics(),
-                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 2,
-                    childAspectRatio: 0.72,
-                    crossAxisSpacing: 12,
-                    mainAxisSpacing: 12,
-                  ),
-                  itemCount: 4,
-                  itemBuilder: (_, i) => _buildProductPlaceholder(),
-                ),
-              ),
-              const SizedBox(height: 24),
             ],
           ),
         ),
@@ -141,7 +181,11 @@ class HomeScreen extends StatelessWidget {
     );
   }
 
-  static Widget _buildSectionHeader(BuildContext context, String title, VoidCallback onSeeAll) {
+  static Widget _buildSectionHeader(
+    BuildContext context,
+    String title,
+    VoidCallback onSeeAll,
+  ) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16),
       child: Row(
@@ -152,7 +196,11 @@ class HomeScreen extends StatelessWidget {
             onTap: onSeeAll,
             child: const Text(
               AppStrings.seeAll,
-              style: TextStyle(color: AppColors.primary, fontWeight: FontWeight.w500, fontSize: 13),
+              style: TextStyle(
+                color: AppColors.primary,
+                fontWeight: FontWeight.w500,
+                fontSize: 13,
+              ),
             ),
           ),
         ],
@@ -160,48 +208,114 @@ class HomeScreen extends StatelessWidget {
     );
   }
 
-  static Widget _buildProductPlaceholder() {
-    return Container(
-      width: 160,
-      margin: const EdgeInsets.only(right: 12),
-      decoration: BoxDecoration(
-        color: AppColors.white,
-        borderRadius: BorderRadius.circular(12),
-        boxShadow: [
-          BoxShadow(
-            color: AppColors.shadow.withValues(alpha: 0.08),
-            blurRadius: 8,
-            offset: const Offset(0, 2),
-          ),
-        ],
+  Widget _buildHorizontalProductList(
+    BuildContext context,
+    List<ProductModel> products,
+  ) {
+    return SizedBox(
+      height: 230,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        itemCount: products.length,
+        itemBuilder: (context, index) {
+          final product = products[index];
+          return SizedBox(
+            width: 160,
+            child: Padding(
+              padding: const EdgeInsets.only(right: 12),
+              child: ProductCard(
+                id: product.id,
+                name: product.name,
+                imageUrl: product.imageUrl,
+                price: product.price,
+                originalPrice: product.originalPrice,
+                rating: product.rating,
+                reviewCount: product.reviewCount,
+                discountPercent: product.discountPercent,
+                onTap: () => context.push('/product/${product.id}'),
+                onAddToCart: () {},
+                onWishlistToggle: () {},
+              ),
+            ),
+          );
+        },
       ),
-      child: const Center(child: Icon(Icons.image, color: AppColors.textHint, size: 40)),
+    );
+  }
+
+  Widget _buildProductGrid(
+    BuildContext context,
+    List<ProductModel> products,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: GridView.builder(
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+          childAspectRatio: 0.68,
+          crossAxisSpacing: 12,
+          mainAxisSpacing: 12,
+        ),
+        itemCount: products.length,
+        itemBuilder: (context, index) {
+          final product = products[index];
+          return ProductCard(
+            id: product.id,
+            name: product.name,
+            imageUrl: product.imageUrl,
+            price: product.price,
+            originalPrice: product.originalPrice,
+            rating: product.rating,
+            reviewCount: product.reviewCount,
+            discountPercent: product.discountPercent,
+            onTap: () => context.push('/product/${product.id}'),
+            onAddToCart: () {},
+            onWishlistToggle: () {},
+          );
+        },
+      ),
     );
   }
 }
 
-class _CategoryChip extends StatelessWidget {
-  final String name;
-  const _CategoryChip({required this.name});
+class _ErrorView extends StatelessWidget {
+  final String message;
+  final VoidCallback onRetry;
+
+  const _ErrorView({required this.message, required this.onRetry});
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(right: 16),
-      child: Column(
-        children: [
-          Container(
-            width: 56,
-            height: 56,
-            decoration: BoxDecoration(
-              color: AppColors.primaryLight,
-              borderRadius: BorderRadius.circular(16),
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(
+              Icons.error_outline,
+              size: 64,
+              color: AppColors.textHint,
             ),
-            child: const Icon(Icons.category, color: AppColors.primaryDark),
-          ),
-          const SizedBox(height: 6),
-          Text(name, style: const TextStyle(fontSize: 11, fontWeight: FontWeight.w500)),
-        ],
+            const SizedBox(height: 16),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: AppColors.textSecondary,
+                fontSize: 16,
+              ),
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton(
+              onPressed: onRetry,
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/home/presentation/widgets/banner_carousel.dart
+++ b/lib/features/home/presentation/widgets/banner_carousel.dart
@@ -1,0 +1,177 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:smooth_page_indicator/smooth_page_indicator.dart';
+import '../../../../core/constants/app_colors.dart';
+import '../../data/models/banner_model.dart';
+
+class BannerCarousel extends StatefulWidget {
+  final List<BannerModel> banners;
+
+  const BannerCarousel({super.key, required this.banners});
+
+  @override
+  State<BannerCarousel> createState() => _BannerCarouselState();
+}
+
+class _BannerCarouselState extends State<BannerCarousel> {
+  final _pageController = PageController();
+  Timer? _autoScrollTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _startAutoScroll();
+  }
+
+  @override
+  void dispose() {
+    _autoScrollTimer?.cancel();
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  void _startAutoScroll() {
+    if (widget.banners.length <= 1) return;
+    _autoScrollTimer = Timer.periodic(const Duration(seconds: 4), (_) {
+      if (!_pageController.hasClients) return;
+      final nextPage = ((_pageController.page?.round() ?? 0) + 1) %
+          widget.banners.length;
+      _pageController.animateToPage(
+        nextPage,
+        duration: const Duration(milliseconds: 400),
+        curve: Curves.easeInOut,
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.banners.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      children: [
+        SizedBox(
+          height: 160,
+          child: PageView.builder(
+            controller: _pageController,
+            itemCount: widget.banners.length,
+            itemBuilder: (context, index) {
+              final banner = widget.banners[index];
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(16),
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      CachedNetworkImage(
+                        imageUrl: banner.imageUrl,
+                        fit: BoxFit.cover,
+                        placeholder: (context, url) => Container(
+                          color: AppColors.primaryLight,
+                        ),
+                        errorWidget: (context, url, error) => Container(
+                          color: AppColors.primaryLight,
+                          child: Center(
+                            child: Column(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                const Icon(
+                                  Icons.local_grocery_store,
+                                  color: AppColors.primaryDark,
+                                  size: 40,
+                                ),
+                                if (banner.title != null) ...[
+                                  const SizedBox(height: 8),
+                                  Text(
+                                    banner.title!,
+                                    style: const TextStyle(
+                                      color: AppColors.primaryDark,
+                                      fontWeight: FontWeight.w700,
+                                      fontSize: 18,
+                                    ),
+                                  ),
+                                ],
+                                if (banner.subtitle != null) ...[
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    banner.subtitle!,
+                                    style: const TextStyle(
+                                      color: AppColors.primaryDark,
+                                      fontSize: 13,
+                                    ),
+                                  ),
+                                ],
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                      if (banner.title != null)
+                        Positioned(
+                          bottom: 0,
+                          left: 0,
+                          right: 0,
+                          child: Container(
+                            padding: const EdgeInsets.all(12),
+                            decoration: BoxDecoration(
+                              gradient: LinearGradient(
+                                begin: Alignment.bottomCenter,
+                                end: Alignment.topCenter,
+                                colors: [
+                                  Colors.black.withValues(alpha: 0.6),
+                                  Colors.transparent,
+                                ],
+                              ),
+                            ),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(
+                                  banner.title!,
+                                  style: const TextStyle(
+                                    color: AppColors.white,
+                                    fontWeight: FontWeight.w700,
+                                    fontSize: 16,
+                                  ),
+                                ),
+                                if (banner.subtitle != null)
+                                  Text(
+                                    banner.subtitle!,
+                                    style: TextStyle(
+                                      color: AppColors.white
+                                          .withValues(alpha: 0.9),
+                                      fontSize: 12,
+                                    ),
+                                  ),
+                              ],
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        if (widget.banners.length > 1) ...[
+          const SizedBox(height: 12),
+          SmoothPageIndicator(
+            controller: _pageController,
+            count: widget.banners.length,
+            effect: const ExpandingDotsEffect(
+              dotHeight: 6,
+              dotWidth: 6,
+              activeDotColor: AppColors.primary,
+              dotColor: AppColors.divider,
+              expansionFactor: 3,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/category_scroll.dart
+++ b/lib/features/home/presentation/widgets/category_scroll.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../../../../core/constants/app_colors.dart';
+import '../../data/models/category_model.dart';
+
+class CategoryScroll extends StatelessWidget {
+  final List<CategoryModel> categories;
+  final ValueChanged<CategoryModel>? onCategoryTap;
+
+  const CategoryScroll({
+    super.key,
+    required this.categories,
+    this.onCategoryTap,
+  });
+
+  static const _categoryIcons = <String, IconData>{
+    'grocery': Icons.shopping_basket,
+    'meats': Icons.restaurant,
+    'fish': Icons.set_meal,
+    'drinks': Icons.local_drink,
+    'bakery': Icons.bakery_dining,
+    'fruits': Icons.apple,
+    'poultry': Icons.egg,
+    'others': Icons.more_horiz,
+    'african': Icons.public,
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 90,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        itemCount: categories.length,
+        itemBuilder: (context, index) {
+          final category = categories[index];
+          return _CategoryItem(
+            category: category,
+            icon: _categoryIcons[category.name.toLowerCase()] ??
+                Icons.category,
+            onTap: () => onCategoryTap?.call(category),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _CategoryItem extends StatelessWidget {
+  final CategoryModel category;
+  final IconData icon;
+  final VoidCallback? onTap;
+
+  const _CategoryItem({
+    required this.category,
+    required this.icon,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.only(right: 16),
+        child: Column(
+          children: [
+            Container(
+              width: 56,
+              height: 56,
+              decoration: BoxDecoration(
+                color: AppColors.primaryLight,
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: category.iconUrl != null
+                  ? ClipRRect(
+                      borderRadius: BorderRadius.circular(16),
+                      child: CachedNetworkImage(
+                        imageUrl: category.iconUrl!,
+                        fit: BoxFit.cover,
+                        errorWidget: (context, url, error) =>
+                            Icon(icon, color: AppColors.primaryDark),
+                      ),
+                    )
+                  : Icon(icon, color: AppColors.primaryDark),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              category.name,
+              style: const TextStyle(
+                fontSize: 11,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/widgets/home_shimmer.dart
+++ b/lib/features/home/presentation/widgets/home_shimmer.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+import '../../../../core/constants/app_colors.dart';
+
+class HomeShimmer extends StatelessWidget {
+  const HomeShimmer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Shimmer.fromColors(
+      baseColor: AppColors.surface,
+      highlightColor: AppColors.white,
+      child: SingleChildScrollView(
+        physics: const NeverScrollableScrollPhysics(),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Banner shimmer
+            Container(
+              height: 160,
+              margin: const EdgeInsets.symmetric(horizontal: 16),
+              decoration: BoxDecoration(
+                color: AppColors.surface,
+                borderRadius: BorderRadius.circular(16),
+              ),
+            ),
+            const SizedBox(height: 20),
+            // Categories shimmer
+            _sectionTitleShimmer(),
+            const SizedBox(height: 12),
+            SizedBox(
+              height: 90,
+              child: ListView.builder(
+                scrollDirection: Axis.horizontal,
+                physics: const NeverScrollableScrollPhysics(),
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                itemCount: 6,
+                itemBuilder: (context, index) => Padding(
+                  padding: const EdgeInsets.only(right: 16),
+                  child: Column(
+                    children: [
+                      Container(
+                        width: 56,
+                        height: 56,
+                        decoration: BoxDecoration(
+                          color: AppColors.surface,
+                          borderRadius: BorderRadius.circular(16),
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Container(
+                        width: 40,
+                        height: 10,
+                        color: AppColors.surface,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            // Featured products shimmer
+            _sectionTitleShimmer(),
+            const SizedBox(height: 12),
+            SizedBox(
+              height: 220,
+              child: ListView.builder(
+                scrollDirection: Axis.horizontal,
+                physics: const NeverScrollableScrollPhysics(),
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                itemCount: 3,
+                itemBuilder: (context, index) => _productCardShimmer(),
+              ),
+            ),
+            const SizedBox(height: 20),
+            // Best selling shimmer
+            _sectionTitleShimmer(),
+            const SizedBox(height: 12),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Row(
+                children: [
+                  Expanded(child: _gridProductShimmer()),
+                  const SizedBox(width: 12),
+                  Expanded(child: _gridProductShimmer()),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _sectionTitleShimmer() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Container(width: 120, height: 16, color: AppColors.surface),
+          Container(width: 40, height: 12, color: AppColors.surface),
+        ],
+      ),
+    );
+  }
+
+  Widget _productCardShimmer() {
+    return Container(
+      width: 160,
+      margin: const EdgeInsets.only(right: 12),
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            height: 140,
+            decoration: const BoxDecoration(
+              color: AppColors.surface,
+              borderRadius: BorderRadius.vertical(top: Radius.circular(12)),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(10),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(height: 12, width: 100, color: AppColors.surface),
+                const SizedBox(height: 6),
+                Container(height: 12, width: 60, color: AppColors.surface),
+                const SizedBox(height: 6),
+                Container(height: 10, width: 40, color: AppColors.surface),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _gridProductShimmer() {
+    return Container(
+      height: 220,
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            height: 140,
+            decoration: const BoxDecoration(
+              color: AppColors.surface,
+              borderRadius: BorderRadius.vertical(top: Radius.circular(12)),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(10),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(height: 12, width: 100, color: AppColors.surface),
+                const SizedBox(height: 6),
+                Container(height: 12, width: 60, color: AppColors.surface),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Full Home Screen implementation with Clean Architecture (data/domain/presentation layers)
- Banner carousel with auto-scroll and smooth page indicators
- Category horizontal scroll with mapped icons, navigates to product listing
- Featured Products (horizontal), Best Selling & Popular Products (2-column grids)
- HomeCubit state management with loading/loaded/error states
- Mock datasource for frontend-first development
- Shimmer loading placeholders, pull-to-refresh, error view with retry
- ProductCard integration with navigation to product detail

## Test plan
- [ ] App launches and navigates to Home after auth
- [ ] Shimmer loading appears briefly before mock data loads
- [ ] Banner auto-scrolls every 4 seconds with page indicators
- [ ] Categories scroll horizontally with correct icons
- [ ] Tapping category navigates to `/products/:categoryId`
- [ ] Tapping product card navigates to `/product/:id`
- [ ] Pull-to-refresh reloads all sections
- [ ] Search bar tap navigates to `/search`

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)