### PR TITLE
feat: implement Categories, Product Listing & Search

### DIFF
--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -11,6 +11,11 @@ import '../../features/home/data/datasources/home_mock_datasource.dart';
 import '../../features/home/data/repositories/home_repository_impl.dart';
 import '../../features/home/domain/repositories/home_repository.dart';
 import '../../features/home/presentation/cubit/home_cubit.dart';
+import '../../features/categories/data/datasources/categories_mock_datasource.dart';
+import '../../features/categories/data/repositories/categories_repository_impl.dart';
+import '../../features/categories/domain/repositories/categories_repository.dart';
+import '../../features/categories/presentation/cubit/categories_cubit.dart';
+import '../../features/categories/presentation/cubit/search_cubit.dart';
 
 final getIt = GetIt.instance;
 
@@ -50,5 +55,19 @@ Future<void> configureDependencies() async {
   );
   getIt.registerFactory<HomeCubit>(
     () => HomeCubit(getIt<HomeRepository>()),
+  );
+
+  // Categories
+  getIt.registerLazySingleton<CategoriesMockDatasource>(
+    () => CategoriesMockDatasource(),
+  );
+  getIt.registerLazySingleton<CategoriesRepository>(
+    () => CategoriesRepositoryImpl(getIt<CategoriesMockDatasource>()),
+  );
+  getIt.registerFactory<CategoriesCubit>(
+    () => CategoriesCubit(getIt<CategoriesRepository>()),
+  );
+  getIt.registerFactory<SearchCubit>(
+    () => SearchCubit(getIt<CategoriesRepository>()),
   );
 }

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -3,6 +3,10 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import '../di/injection.dart';
 import '../../features/home/presentation/cubit/home_cubit.dart';
+import '../../features/categories/presentation/cubit/categories_cubit.dart';
+import '../../features/categories/presentation/cubit/product_list_cubit.dart';
+import '../../features/categories/presentation/cubit/search_cubit.dart';
+import '../../features/categories/domain/repositories/categories_repository.dart';
 import '../../features/auth/presentation/screens/splash_screen.dart';
 import '../../features/auth/presentation/screens/sign_in_screen.dart';
 import '../../features/auth/presentation/screens/sign_up_screen.dart';
@@ -117,18 +121,33 @@ class AppRouter {
       // Categories & Search
       GoRoute(
         path: '/categories',
-        builder: (context, state) => const CategoriesScreen(),
+        builder: (context, state) => BlocProvider(
+          create: (_) => getIt<CategoriesCubit>()..loadCategories(),
+          child: const CategoriesScreen(),
+        ),
       ),
       GoRoute(
         path: '/search',
-        builder: (context, state) => const SearchScreen(),
+        builder: (context, state) => BlocProvider(
+          create: (_) => getIt<SearchCubit>()..init(),
+          child: const SearchScreen(),
+        ),
       ),
       GoRoute(
         path: '/products/:categoryId',
-        builder: (context, state) => ProductListScreen(
-          categoryId: state.pathParameters['categoryId']!,
-          categoryName: state.extra as String? ?? 'Products',
-        ),
+        builder: (context, state) {
+          final categoryId = state.pathParameters['categoryId']!;
+          return BlocProvider(
+            create: (_) => ProductListCubit(
+              repository: getIt<CategoriesRepository>(),
+              categoryId: categoryId,
+            )..loadProducts(),
+            child: ProductListScreen(
+              categoryId: categoryId,
+              categoryName: state.extra as String? ?? 'Products',
+            ),
+          );
+        },
       ),
 
       // Product Detail

--- a/lib/features/categories/data/datasources/categories_mock_datasource.dart
+++ b/lib/features/categories/data/datasources/categories_mock_datasource.dart
@@ -1,0 +1,239 @@
+import '../../../home/data/models/category_model.dart';
+import '../../../home/data/models/product_model.dart';
+
+class CategoriesMockDatasource {
+  Future<List<CategoryModel>> getCategories() async {
+    await Future.delayed(const Duration(milliseconds: 600));
+    return const [
+      CategoryModel(id: '1', name: 'Grocery'),
+      CategoryModel(id: '2', name: 'Meats'),
+      CategoryModel(id: '3', name: 'Fish'),
+      CategoryModel(id: '4', name: 'Drinks'),
+      CategoryModel(id: '5', name: 'Bakery'),
+      CategoryModel(id: '6', name: 'Fruits'),
+      CategoryModel(id: '7', name: 'Poultry'),
+      CategoryModel(id: '8', name: 'Sweets'),
+      CategoryModel(id: '9', name: 'Noodles'),
+      CategoryModel(id: '10', name: 'Frozen'),
+      CategoryModel(id: '11', name: 'Others'),
+      CategoryModel(id: '12', name: 'African'),
+    ];
+  }
+
+  Future<List<ProductModel>> getCategoryProducts({
+    required String categoryId,
+    int page = 1,
+    String? sort,
+  }) async {
+    await Future.delayed(const Duration(milliseconds: 700));
+    // Return mock products; in real implementation filtered by categoryId
+    final allProducts = _mockProducts;
+    final start = (page - 1) * 10;
+    if (start >= allProducts.length) return [];
+
+    var products = allProducts.sublist(
+      start,
+      (start + 10).clamp(0, allProducts.length),
+    );
+
+    if (sort != null) {
+      switch (sort) {
+        case 'price_low':
+          products = List.from(products)
+            ..sort((a, b) => a.price.compareTo(b.price));
+        case 'price_high':
+          products = List.from(products)
+            ..sort((a, b) => b.price.compareTo(a.price));
+        case 'rating':
+          products = List.from(products)
+            ..sort((a, b) =>
+                (b.rating ?? 0).compareTo(a.rating ?? 0));
+        case 'newest':
+          products = List.from(products.reversed);
+      }
+    }
+
+    return products;
+  }
+
+  Future<List<ProductModel>> searchProducts({
+    required String query,
+    int page = 1,
+  }) async {
+    await Future.delayed(const Duration(milliseconds: 500));
+    final filtered = _mockProducts
+        .where((p) => p.name.toLowerCase().contains(query.toLowerCase()))
+        .toList();
+    final start = (page - 1) * 10;
+    if (start >= filtered.length) return [];
+    return filtered.sublist(start, (start + 10).clamp(0, filtered.length));
+  }
+
+  Future<List<String>> getSearchSuggestions(String query) async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    if (query.isEmpty) return [];
+    return _mockProducts
+        .map((p) => p.name)
+        .where((name) => name.toLowerCase().contains(query.toLowerCase()))
+        .take(5)
+        .toList();
+  }
+
+  static const _mockProducts = [
+    ProductModel(
+      id: '1',
+      name: 'Sunflower Oil',
+      imageUrl: 'https://via.placeholder.com/300x300/FFF9C4/212121?text=Sunflower+Oil',
+      price: 59.00,
+      originalPrice: 75.00,
+      rating: 4.5,
+      reviewCount: 120,
+      discountPercent: 21,
+      unit: '1L',
+    ),
+    ProductModel(
+      id: '2',
+      name: 'Chicken Sharma',
+      imageUrl: 'https://via.placeholder.com/300x300/FFCCBC/212121?text=Chicken',
+      price: 140.00,
+      originalPrice: 160.00,
+      rating: 4.8,
+      reviewCount: 89,
+      discountPercent: 12,
+      unit: '1kg',
+    ),
+    ProductModel(
+      id: '3',
+      name: 'Fresh Tilapia',
+      imageUrl: 'https://via.placeholder.com/300x300/B3E5FC/212121?text=Tilapia',
+      price: 95.00,
+      originalPrice: 120.00,
+      rating: 4.3,
+      reviewCount: 67,
+      discountPercent: 20,
+      unit: '1kg',
+    ),
+    ProductModel(
+      id: '4',
+      name: 'Jollof Rice Mix',
+      imageUrl: 'https://via.placeholder.com/300x300/FFECB3/212121?text=Jollof+Rice',
+      price: 25.00,
+      rating: 4.7,
+      reviewCount: 203,
+      unit: '500g',
+    ),
+    ProductModel(
+      id: '5',
+      name: 'Palm Oil',
+      imageUrl: 'https://via.placeholder.com/300x300/FFE0B2/212121?text=Palm+Oil',
+      price: 45.00,
+      originalPrice: 55.00,
+      rating: 4.6,
+      reviewCount: 156,
+      discountPercent: 18,
+      unit: '1L',
+    ),
+    ProductModel(
+      id: '6',
+      name: 'Cassava Flour',
+      imageUrl: 'https://via.placeholder.com/300x300/FFF9C4/212121?text=Cassava+Flour',
+      price: 18.00,
+      originalPrice: 22.00,
+      rating: 4.4,
+      reviewCount: 312,
+      discountPercent: 18,
+      unit: '1kg',
+    ),
+    ProductModel(
+      id: '7',
+      name: 'Egusi Seeds',
+      imageUrl: 'https://via.placeholder.com/300x300/C8E6C9/212121?text=Egusi+Seeds',
+      price: 32.00,
+      rating: 4.6,
+      reviewCount: 245,
+      unit: '500g',
+    ),
+    ProductModel(
+      id: '8',
+      name: 'Plantain Chips',
+      imageUrl: 'https://via.placeholder.com/300x300/FFE0B2/212121?text=Plantain+Chips',
+      price: 12.00,
+      originalPrice: 15.00,
+      rating: 4.2,
+      reviewCount: 189,
+      discountPercent: 20,
+      unit: '200g',
+    ),
+    ProductModel(
+      id: '9',
+      name: 'Dried Stockfish',
+      imageUrl: 'https://via.placeholder.com/300x300/FFCCBC/212121?text=Stockfish',
+      price: 85.00,
+      originalPrice: 100.00,
+      rating: 4.7,
+      reviewCount: 134,
+      discountPercent: 15,
+      unit: '500g',
+    ),
+    ProductModel(
+      id: '10',
+      name: 'Suya Spice Mix',
+      imageUrl: 'https://via.placeholder.com/300x300/FFCCBC/212121?text=Suya+Spice',
+      price: 15.00,
+      rating: 4.8,
+      reviewCount: 420,
+      unit: '200g',
+    ),
+    ProductModel(
+      id: '11',
+      name: 'Shea Butter',
+      imageUrl: 'https://via.placeholder.com/300x300/FFF9C4/212121?text=Shea+Butter',
+      price: 28.00,
+      originalPrice: 35.00,
+      rating: 4.5,
+      reviewCount: 276,
+      discountPercent: 20,
+      unit: '250g',
+    ),
+    ProductModel(
+      id: '12',
+      name: 'Yam Flour (Poundo)',
+      imageUrl: 'https://via.placeholder.com/300x300/C8E6C9/212121?text=Yam+Flour',
+      price: 22.00,
+      rating: 4.3,
+      reviewCount: 198,
+      unit: '1kg',
+    ),
+    ProductModel(
+      id: '13',
+      name: 'Groundnut Paste',
+      imageUrl: 'https://via.placeholder.com/300x300/FFE0B2/212121?text=Groundnut',
+      price: 19.00,
+      originalPrice: 24.00,
+      rating: 4.4,
+      reviewCount: 167,
+      discountPercent: 20,
+      unit: '500g',
+    ),
+    ProductModel(
+      id: '14',
+      name: 'Okra (Frozen)',
+      imageUrl: 'https://via.placeholder.com/300x300/C8E6C9/212121?text=Okra',
+      price: 8.00,
+      rating: 4.1,
+      reviewCount: 95,
+      unit: '500g',
+    ),
+    ProductModel(
+      id: '15',
+      name: 'Fufu Flour',
+      imageUrl: 'https://via.placeholder.com/300x300/FFF9C4/212121?text=Fufu+Flour',
+      price: 16.00,
+      originalPrice: 20.00,
+      rating: 4.5,
+      reviewCount: 230,
+      discountPercent: 20,
+      unit: '1kg',
+    ),
+  ];
+}

--- a/lib/features/categories/data/datasources/categories_remote_datasource.dart
+++ b/lib/features/categories/data/datasources/categories_remote_datasource.dart
@@ -1,0 +1,80 @@
+import 'package:dio/dio.dart';
+import '../../../../core/api/api_exceptions.dart';
+import '../../../../core/constants/api_endpoints.dart';
+import '../../../home/data/models/category_model.dart';
+import '../../../home/data/models/product_model.dart';
+
+class CategoriesRemoteDatasource {
+  final Dio _dio;
+
+  CategoriesRemoteDatasource(this._dio);
+
+  Future<List<CategoryModel>> getCategories() async {
+    try {
+      final response = await _dio.get(ApiEndpoints.categories);
+      final data = response.data as Map<String, dynamic>;
+      final list = data['data'] as List<dynamic>? ?? [];
+      return list
+          .map((e) => CategoryModel.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+
+  Future<List<ProductModel>> getCategoryProducts({
+    required String categoryId,
+    int page = 1,
+    String? sort,
+  }) async {
+    try {
+      final response = await _dio.get(
+        ApiEndpoints.categoryProducts(categoryId),
+        queryParameters: {
+          'page': page,
+          if (sort != null) 'sort': sort,
+        },
+      );
+      final data = response.data as Map<String, dynamic>;
+      final list = data['data'] as List<dynamic>? ?? [];
+      return list
+          .map((e) => ProductModel.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+
+  Future<List<ProductModel>> searchProducts({
+    required String query,
+    int page = 1,
+  }) async {
+    try {
+      final response = await _dio.get(
+        ApiEndpoints.searchProducts,
+        queryParameters: {'q': query, 'page': page},
+      );
+      final data = response.data as Map<String, dynamic>;
+      final list = data['data'] as List<dynamic>? ?? [];
+      return list
+          .map((e) => ProductModel.fromJson(e as Map<String, dynamic>))
+          .toList();
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+
+  Future<List<String>> getSearchSuggestions(String query) async {
+    try {
+      final response = await _dio.get(
+        ApiEndpoints.searchSuggestions,
+        queryParameters: {'q': query},
+      );
+      final data = response.data as Map<String, dynamic>;
+      final list = data['data'] as List<dynamic>? ?? [];
+      return list.map((e) => e.toString()).toList();
+    } on DioException catch (e) {
+      throw ApiException.fromDioException(e);
+    }
+  }
+}

--- a/lib/features/categories/data/repositories/categories_repository_impl.dart
+++ b/lib/features/categories/data/repositories/categories_repository_impl.dart
@@ -1,0 +1,68 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/api/api_exceptions.dart';
+import '../../../home/data/models/category_model.dart';
+import '../../../home/data/models/product_model.dart';
+import '../../domain/repositories/categories_repository.dart';
+import '../datasources/categories_mock_datasource.dart';
+
+class CategoriesRepositoryImpl implements CategoriesRepository {
+  final CategoriesMockDatasource _mockDatasource;
+
+  CategoriesRepositoryImpl(this._mockDatasource);
+
+  @override
+  Future<Either<ApiException, List<CategoryModel>>> getCategories() async {
+    try {
+      final categories = await _mockDatasource.getCategories();
+      return Right(categories);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+
+  @override
+  Future<Either<ApiException, List<ProductModel>>> getCategoryProducts({
+    required String categoryId,
+    int page = 1,
+    String? sort,
+  }) async {
+    try {
+      final products = await _mockDatasource.getCategoryProducts(
+        categoryId: categoryId,
+        page: page,
+        sort: sort,
+      );
+      return Right(products);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+
+  @override
+  Future<Either<ApiException, List<ProductModel>>> searchProducts({
+    required String query,
+    int page = 1,
+  }) async {
+    try {
+      final products = await _mockDatasource.searchProducts(
+        query: query,
+        page: page,
+      );
+      return Right(products);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+
+  @override
+  Future<Either<ApiException, List<String>>> getSearchSuggestions(
+    String query,
+  ) async {
+    try {
+      final suggestions = await _mockDatasource.getSearchSuggestions(query);
+      return Right(suggestions);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+}

--- a/lib/features/categories/domain/repositories/categories_repository.dart
+++ b/lib/features/categories/domain/repositories/categories_repository.dart
@@ -1,0 +1,21 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/api/api_exceptions.dart';
+import '../../../home/data/models/category_model.dart';
+import '../../../home/data/models/product_model.dart';
+
+abstract class CategoriesRepository {
+  Future<Either<ApiException, List<CategoryModel>>> getCategories();
+
+  Future<Either<ApiException, List<ProductModel>>> getCategoryProducts({
+    required String categoryId,
+    int page = 1,
+    String? sort,
+  });
+
+  Future<Either<ApiException, List<ProductModel>>> searchProducts({
+    required String query,
+    int page = 1,
+  });
+
+  Future<Either<ApiException, List<String>>> getSearchSuggestions(String query);
+}

--- a/lib/features/categories/presentation/cubit/categories_cubit.dart
+++ b/lib/features/categories/presentation/cubit/categories_cubit.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../domain/repositories/categories_repository.dart';
+import 'categories_state.dart';
+
+class CategoriesCubit extends Cubit<CategoriesState> {
+  final CategoriesRepository _repository;
+
+  CategoriesCubit(this._repository) : super(const CategoriesState());
+
+  Future<void> loadCategories() async {
+    emit(state.copyWith(status: CategoriesStatus.loading));
+
+    final result = await _repository.getCategories();
+
+    result.fold(
+      (error) => emit(state.copyWith(
+        status: CategoriesStatus.error,
+        errorMessage: error.message,
+      )),
+      (categories) => emit(state.copyWith(
+        status: CategoriesStatus.loaded,
+        categories: categories,
+      )),
+    );
+  }
+}

--- a/lib/features/categories/presentation/cubit/categories_state.dart
+++ b/lib/features/categories/presentation/cubit/categories_state.dart
@@ -1,0 +1,27 @@
+import '../../../home/data/models/category_model.dart';
+
+enum CategoriesStatus { initial, loading, loaded, error }
+
+class CategoriesState {
+  final CategoriesStatus status;
+  final List<CategoryModel> categories;
+  final String? errorMessage;
+
+  const CategoriesState({
+    this.status = CategoriesStatus.initial,
+    this.categories = const [],
+    this.errorMessage,
+  });
+
+  CategoriesState copyWith({
+    CategoriesStatus? status,
+    List<CategoryModel>? categories,
+    String? errorMessage,
+  }) {
+    return CategoriesState(
+      status: status ?? this.status,
+      categories: categories ?? this.categories,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+}

--- a/lib/features/categories/presentation/cubit/product_list_cubit.dart
+++ b/lib/features/categories/presentation/cubit/product_list_cubit.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../domain/repositories/categories_repository.dart';
+import 'product_list_state.dart';
+
+class ProductListCubit extends Cubit<ProductListState> {
+  final CategoriesRepository _repository;
+  final String categoryId;
+
+  ProductListCubit({
+    required CategoriesRepository repository,
+    required this.categoryId,
+  })  : _repository = repository,
+        super(const ProductListState());
+
+  Future<void> loadProducts() async {
+    emit(state.copyWith(
+      status: ProductListStatus.loading,
+      currentPage: 1,
+      hasReachedEnd: false,
+    ));
+
+    final result = await _repository.getCategoryProducts(
+      categoryId: categoryId,
+      page: 1,
+      sort: state.activeSort,
+    );
+
+    result.fold(
+      (error) => emit(state.copyWith(
+        status: ProductListStatus.error,
+        errorMessage: error.message,
+      )),
+      (products) => emit(state.copyWith(
+        status: ProductListStatus.loaded,
+        products: products,
+        currentPage: 1,
+        hasReachedEnd: products.length < 10,
+      )),
+    );
+  }
+
+  Future<void> loadMore() async {
+    if (state.hasReachedEnd ||
+        state.status == ProductListStatus.loadingMore) {
+      return;
+    }
+
+    final nextPage = state.currentPage + 1;
+    emit(state.copyWith(status: ProductListStatus.loadingMore));
+
+    final result = await _repository.getCategoryProducts(
+      categoryId: categoryId,
+      page: nextPage,
+      sort: state.activeSort,
+    );
+
+    result.fold(
+      (error) => emit(state.copyWith(
+        status: ProductListStatus.loaded,
+        errorMessage: error.message,
+      )),
+      (products) => emit(state.copyWith(
+        status: ProductListStatus.loaded,
+        products: [...state.products, ...products],
+        currentPage: nextPage,
+        hasReachedEnd: products.length < 10,
+      )),
+    );
+  }
+
+  Future<void> changeSort(String? sort) async {
+    emit(state.copyWith(activeSort: sort));
+    await loadProducts();
+  }
+
+  void toggleViewMode() {
+    emit(state.copyWith(isGridView: !state.isGridView));
+  }
+}

--- a/lib/features/categories/presentation/cubit/product_list_state.dart
+++ b/lib/features/categories/presentation/cubit/product_list_state.dart
@@ -1,0 +1,43 @@
+import '../../../home/data/models/product_model.dart';
+
+enum ProductListStatus { initial, loading, loaded, loadingMore, error }
+
+class ProductListState {
+  final ProductListStatus status;
+  final List<ProductModel> products;
+  final String? errorMessage;
+  final int currentPage;
+  final bool hasReachedEnd;
+  final String? activeSort;
+  final bool isGridView;
+
+  const ProductListState({
+    this.status = ProductListStatus.initial,
+    this.products = const [],
+    this.errorMessage,
+    this.currentPage = 1,
+    this.hasReachedEnd = false,
+    this.activeSort,
+    this.isGridView = true,
+  });
+
+  ProductListState copyWith({
+    ProductListStatus? status,
+    List<ProductModel>? products,
+    String? errorMessage,
+    int? currentPage,
+    bool? hasReachedEnd,
+    String? activeSort,
+    bool? isGridView,
+  }) {
+    return ProductListState(
+      status: status ?? this.status,
+      products: products ?? this.products,
+      errorMessage: errorMessage ?? this.errorMessage,
+      currentPage: currentPage ?? this.currentPage,
+      hasReachedEnd: hasReachedEnd ?? this.hasReachedEnd,
+      activeSort: activeSort ?? this.activeSort,
+      isGridView: isGridView ?? this.isGridView,
+    );
+  }
+}

--- a/lib/features/categories/presentation/cubit/search_cubit.dart
+++ b/lib/features/categories/presentation/cubit/search_cubit.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../../domain/repositories/categories_repository.dart';
+import 'search_state.dart';
+
+class SearchCubit extends Cubit<SearchState> {
+  final CategoriesRepository _repository;
+  static const _recentSearchesKey = 'recent_searches';
+  static const _maxRecentSearches = 10;
+
+  SearchCubit(this._repository) : super(const SearchState());
+
+  Future<void> init() async {
+    final prefs = await SharedPreferences.getInstance();
+    final recent = prefs.getStringList(_recentSearchesKey) ?? [];
+    emit(state.copyWith(recentSearches: recent));
+  }
+
+  Future<void> updateSuggestions(String query) async {
+    if (query.trim().isEmpty) {
+      emit(state.copyWith(suggestions: [], query: ''));
+      return;
+    }
+
+    emit(state.copyWith(query: query));
+
+    final result = await _repository.getSearchSuggestions(query);
+    result.fold(
+      (error) {},
+      (suggestions) => emit(state.copyWith(suggestions: suggestions)),
+    );
+  }
+
+  Future<void> search(String query) async {
+    if (query.trim().isEmpty) return;
+
+    emit(state.copyWith(
+      status: SearchStatus.loading,
+      query: query,
+      suggestions: [],
+      currentPage: 1,
+      hasReachedEnd: false,
+    ));
+
+    await _saveRecentSearch(query);
+
+    final result = await _repository.searchProducts(
+      query: query,
+      page: 1,
+    );
+
+    result.fold(
+      (error) => emit(state.copyWith(
+        status: SearchStatus.error,
+        errorMessage: error.message,
+      )),
+      (products) => emit(state.copyWith(
+        status: SearchStatus.loaded,
+        results: products,
+        currentPage: 1,
+        hasReachedEnd: products.length < 10,
+      )),
+    );
+  }
+
+  Future<void> loadMore() async {
+    if (state.hasReachedEnd || state.status == SearchStatus.loading) return;
+
+    final nextPage = state.currentPage + 1;
+    final result = await _repository.searchProducts(
+      query: state.query,
+      page: nextPage,
+    );
+
+    result.fold(
+      (error) {},
+      (products) => emit(state.copyWith(
+        results: [...state.results, ...products],
+        currentPage: nextPage,
+        hasReachedEnd: products.length < 10,
+      )),
+    );
+  }
+
+  Future<void> clearRecentSearches() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_recentSearchesKey);
+    emit(state.copyWith(recentSearches: []));
+  }
+
+  Future<void> removeRecentSearch(String query) async {
+    final prefs = await SharedPreferences.getInstance();
+    final recent = List<String>.from(state.recentSearches)..remove(query);
+    await prefs.setStringList(_recentSearchesKey, recent);
+    emit(state.copyWith(recentSearches: recent));
+  }
+
+  Future<void> _saveRecentSearch(String query) async {
+    final prefs = await SharedPreferences.getInstance();
+    final recent = List<String>.from(state.recentSearches)
+      ..remove(query)
+      ..insert(0, query);
+    if (recent.length > _maxRecentSearches) {
+      recent.removeRange(_maxRecentSearches, recent.length);
+    }
+    await prefs.setStringList(_recentSearchesKey, recent);
+    emit(state.copyWith(recentSearches: recent));
+  }
+}

--- a/lib/features/categories/presentation/cubit/search_state.dart
+++ b/lib/features/categories/presentation/cubit/search_state.dart
@@ -1,0 +1,47 @@
+import '../../../home/data/models/product_model.dart';
+
+enum SearchStatus { initial, loading, loaded, error }
+
+class SearchState {
+  final SearchStatus status;
+  final List<ProductModel> results;
+  final List<String> suggestions;
+  final List<String> recentSearches;
+  final String query;
+  final String? errorMessage;
+  final int currentPage;
+  final bool hasReachedEnd;
+
+  const SearchState({
+    this.status = SearchStatus.initial,
+    this.results = const [],
+    this.suggestions = const [],
+    this.recentSearches = const [],
+    this.query = '',
+    this.errorMessage,
+    this.currentPage = 1,
+    this.hasReachedEnd = false,
+  });
+
+  SearchState copyWith({
+    SearchStatus? status,
+    List<ProductModel>? results,
+    List<String>? suggestions,
+    List<String>? recentSearches,
+    String? query,
+    String? errorMessage,
+    int? currentPage,
+    bool? hasReachedEnd,
+  }) {
+    return SearchState(
+      status: status ?? this.status,
+      results: results ?? this.results,
+      suggestions: suggestions ?? this.suggestions,
+      recentSearches: recentSearches ?? this.recentSearches,
+      query: query ?? this.query,
+      errorMessage: errorMessage ?? this.errorMessage,
+      currentPage: currentPage ?? this.currentPage,
+      hasReachedEnd: hasReachedEnd ?? this.hasReachedEnd,
+    );
+  }
+}

--- a/lib/features/categories/presentation/screens/categories_screen.dart
+++ b/lib/features/categories/presentation/screens/categories_screen.dart
@@ -1,13 +1,161 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/app_strings.dart';
+import '../../../../core/widgets/loading_shimmer.dart';
+import '../cubit/categories_cubit.dart';
+import '../cubit/categories_state.dart';
 
 class CategoriesScreen extends StatelessWidget {
   const CategoriesScreen({super.key});
 
+  static const _categoryIcons = <String, IconData>{
+    'grocery': Icons.shopping_basket,
+    'meats': Icons.restaurant,
+    'fish': Icons.set_meal,
+    'drinks': Icons.local_drink,
+    'bakery': Icons.bakery_dining,
+    'fruits': Icons.apple,
+    'poultry': Icons.egg,
+    'sweets': Icons.cake,
+    'noodles': Icons.ramen_dining,
+    'frozen': Icons.ac_unit,
+    'others': Icons.more_horiz,
+    'african': Icons.public,
+  };
+
+  static const _categoryColors = <String, Color>{
+    'grocery': Color(0xFFE8F5E9),
+    'meats': Color(0xFFFFEBEE),
+    'fish': Color(0xFFE3F2FD),
+    'drinks': Color(0xFFFFF3E0),
+    'bakery': Color(0xFFFCE4EC),
+    'fruits': Color(0xFFF1F8E9),
+    'poultry': Color(0xFFFFF8E1),
+    'sweets': Color(0xFFF3E5F5),
+    'noodles': Color(0xFFFFECB3),
+    'frozen': Color(0xFFE0F7FA),
+    'others': Color(0xFFF5F5F5),
+    'african': Color(0xFFE8F5E9),
+  };
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Categories')),
-      body: const Center(child: Text('Categories')),
+      appBar: AppBar(
+        title: const Text(AppStrings.categories),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios, size: 20),
+          onPressed: () => context.pop(),
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.search),
+            onPressed: () => context.push('/search'),
+          ),
+        ],
+      ),
+      body: BlocBuilder<CategoriesCubit, CategoriesState>(
+        builder: (context, state) {
+          if (state.status == CategoriesStatus.loading ||
+              state.status == CategoriesStatus.initial) {
+            return _buildShimmer();
+          }
+
+          if (state.status == CategoriesStatus.error) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(state.errorMessage ?? 'Something went wrong'),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () =>
+                        context.read<CategoriesCubit>().loadCategories(),
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          return GridView.builder(
+            padding: const EdgeInsets.all(16),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 3,
+              childAspectRatio: 0.85,
+              crossAxisSpacing: 16,
+              mainAxisSpacing: 16,
+            ),
+            itemCount: state.categories.length,
+            itemBuilder: (context, index) {
+              final category = state.categories[index];
+              final key = category.name.toLowerCase();
+              final icon = _categoryIcons[key] ?? Icons.category;
+              final color =
+                  _categoryColors[key] ?? AppColors.primaryLight;
+
+              return GestureDetector(
+                onTap: () => context.push(
+                  '/products/${category.id}',
+                  extra: category.name,
+                ),
+                child: Column(
+                  children: [
+                    Container(
+                      width: 72,
+                      height: 72,
+                      decoration: BoxDecoration(
+                        color: color,
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: Icon(
+                        icon,
+                        color: AppColors.primaryDark,
+                        size: 32,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      category.name,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w500,
+                      ),
+                      textAlign: TextAlign.center,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildShimmer() {
+    return GridView.builder(
+      padding: const EdgeInsets.all(16),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 3,
+        childAspectRatio: 0.85,
+        crossAxisSpacing: 16,
+        mainAxisSpacing: 16,
+      ),
+      itemCount: 12,
+      itemBuilder: (context, index) {
+        return Column(
+          children: [
+            LoadingShimmer(height: 72, width: 72, borderRadius: 20),
+            const SizedBox(height: 8),
+            LoadingShimmer(height: 12, width: 50, borderRadius: 4),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/features/categories/presentation/screens/product_list_screen.dart
+++ b/lib/features/categories/presentation/screens/product_list_screen.dart
@@ -1,6 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import '../../../../core/constants/app_colors.dart';
+import '../../../../core/widgets/product_card.dart';
+import '../../../../core/widgets/loading_shimmer.dart';
+import '../cubit/product_list_cubit.dart';
+import '../cubit/product_list_state.dart';
+import '../widgets/empty_state_widget.dart';
 
-class ProductListScreen extends StatelessWidget {
+class ProductListScreen extends StatefulWidget {
   final String categoryId;
   final String categoryName;
 
@@ -11,10 +19,259 @@ class ProductListScreen extends StatelessWidget {
   });
 
   @override
+  State<ProductListScreen> createState() => _ProductListScreenState();
+}
+
+class _ProductListScreenState extends State<ProductListScreen> {
+  final _scrollController = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.pixels >=
+        _scrollController.position.maxScrollExtent - 200) {
+      context.read<ProductListCubit>().loadMore();
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(categoryName)),
-      body: Center(child: Text('Products for \$categoryName')),
+      appBar: AppBar(
+        title: Text(widget.categoryName),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios, size: 20),
+          onPressed: () => context.pop(),
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.search),
+            onPressed: () => context.push('/search'),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          _buildSortChips(),
+          Expanded(
+            child: BlocBuilder<ProductListCubit, ProductListState>(
+              builder: (context, state) {
+                if (state.status == ProductListStatus.loading ||
+                    state.status == ProductListStatus.initial) {
+                  return const ProductGridShimmer(itemCount: 6);
+                }
+
+                if (state.status == ProductListStatus.error &&
+                    state.products.isEmpty) {
+                  return EmptyStateWidget(
+                    title: 'Failed to load products',
+                    subtitle: state.errorMessage,
+                    buttonText: 'Retry',
+                    onButtonPressed: () =>
+                        context.read<ProductListCubit>().loadProducts(),
+                  );
+                }
+
+                if (state.products.isEmpty) {
+                  return const EmptyStateWidget(
+                    title: 'No products found',
+                    subtitle: 'Try a different category or filter',
+                  );
+                }
+
+                return _buildProductList(context, state);
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSortChips() {
+    return BlocBuilder<ProductListCubit, ProductListState>(
+      buildWhen: (prev, curr) =>
+          prev.activeSort != curr.activeSort ||
+          prev.isGridView != curr.isGridView,
+      builder: (context, state) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Row(
+            children: [
+              Expanded(
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    children: [
+                      _SortChip(
+                        label: 'All',
+                        isSelected: state.activeSort == null,
+                        onTap: () =>
+                            context.read<ProductListCubit>().changeSort(null),
+                      ),
+                      _SortChip(
+                        label: 'Popular',
+                        isSelected: state.activeSort == 'rating',
+                        onTap: () => context
+                            .read<ProductListCubit>()
+                            .changeSort('rating'),
+                      ),
+                      _SortChip(
+                        label: 'Newest',
+                        isSelected: state.activeSort == 'newest',
+                        onTap: () => context
+                            .read<ProductListCubit>()
+                            .changeSort('newest'),
+                      ),
+                      _SortChip(
+                        label: 'Price Low',
+                        isSelected: state.activeSort == 'price_low',
+                        onTap: () => context
+                            .read<ProductListCubit>()
+                            .changeSort('price_low'),
+                      ),
+                      _SortChip(
+                        label: 'Price High',
+                        isSelected: state.activeSort == 'price_high',
+                        onTap: () => context
+                            .read<ProductListCubit>()
+                            .changeSort('price_high'),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              GestureDetector(
+                onTap: () =>
+                    context.read<ProductListCubit>().toggleViewMode(),
+                child: Icon(
+                  state.isGridView ? Icons.grid_view : Icons.view_list,
+                  color: AppColors.textSecondary,
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildProductList(BuildContext context, ProductListState state) {
+    if (state.isGridView) {
+      return GridView.builder(
+        controller: _scrollController,
+        padding: const EdgeInsets.all(16),
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 2,
+          childAspectRatio: 0.68,
+          crossAxisSpacing: 12,
+          mainAxisSpacing: 12,
+        ),
+        itemCount: state.products.length +
+            (state.status == ProductListStatus.loadingMore ? 2 : 0),
+        itemBuilder: (context, index) {
+          if (index >= state.products.length) {
+            return const ProductCardShimmer();
+          }
+          final product = state.products[index];
+          return ProductCard(
+            id: product.id,
+            name: product.name,
+            imageUrl: product.imageUrl,
+            price: product.price,
+            originalPrice: product.originalPrice,
+            rating: product.rating,
+            reviewCount: product.reviewCount,
+            discountPercent: product.discountPercent,
+            onTap: () => context.push('/product/${product.id}'),
+            onAddToCart: () {},
+            onWishlistToggle: () {},
+          );
+        },
+      );
+    }
+
+    return ListView.builder(
+      controller: _scrollController,
+      padding: const EdgeInsets.all(16),
+      itemCount: state.products.length +
+          (state.status == ProductListStatus.loadingMore ? 1 : 0),
+      itemBuilder: (context, index) {
+        if (index >= state.products.length) {
+          return const Padding(
+            padding: EdgeInsets.symmetric(vertical: 16),
+            child: Center(child: CircularProgressIndicator()),
+          );
+        }
+        final product = state.products[index];
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child: SizedBox(
+            height: 230,
+            child: ProductCard(
+              id: product.id,
+              name: product.name,
+              imageUrl: product.imageUrl,
+              price: product.price,
+              originalPrice: product.originalPrice,
+              rating: product.rating,
+              reviewCount: product.reviewCount,
+              discountPercent: product.discountPercent,
+              onTap: () => context.push('/product/${product.id}'),
+              onAddToCart: () {},
+              onWishlistToggle: () {},
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SortChip extends StatelessWidget {
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _SortChip({
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 8),
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          decoration: BoxDecoration(
+            color: isSelected ? AppColors.primary : AppColors.surface,
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w500,
+              color: isSelected ? AppColors.white : AppColors.textSecondary,
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/categories/presentation/screens/search_screen.dart
+++ b/lib/features/categories/presentation/screens/search_screen.dart
@@ -1,13 +1,265 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/app_strings.dart';
+import '../../../../core/widgets/product_card.dart';
+import '../../../../core/widgets/loading_shimmer.dart';
+import '../cubit/search_cubit.dart';
+import '../cubit/search_state.dart';
+import '../widgets/empty_state_widget.dart';
 
-class SearchScreen extends StatelessWidget {
+class SearchScreen extends StatefulWidget {
   const SearchScreen({super.key});
+
+  @override
+  State<SearchScreen> createState() => _SearchScreenState();
+}
+
+class _SearchScreenState extends State<SearchScreen> {
+  final _searchController = TextEditingController();
+  final _scrollController = ScrollController();
+  final _focusNode = FocusNode();
+  Timer? _debounce;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode.requestFocus();
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _scrollController.dispose();
+    _focusNode.dispose();
+    _debounce?.cancel();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.pixels >=
+        _scrollController.position.maxScrollExtent - 200) {
+      context.read<SearchCubit>().loadMore();
+    }
+  }
+
+  void _onSearchChanged(String query) {
+    _debounce?.cancel();
+    _debounce = Timer(const Duration(milliseconds: 300), () {
+      context.read<SearchCubit>().updateSuggestions(query);
+    });
+  }
+
+  void _onSearchSubmitted(String query) {
+    _debounce?.cancel();
+    if (query.trim().isNotEmpty) {
+      _focusNode.unfocus();
+      context.read<SearchCubit>().search(query.trim());
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Search')),
-      body: const Center(child: Text('Search')),
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios, size: 20),
+          onPressed: () => context.pop(),
+        ),
+        title: _buildSearchField(),
+        titleSpacing: 0,
+      ),
+      body: BlocBuilder<SearchCubit, SearchState>(
+        builder: (context, state) {
+          // Show suggestions if typing
+          if (state.suggestions.isNotEmpty &&
+              state.status != SearchStatus.loaded) {
+            return _buildSuggestions(state);
+          }
+
+          // Show results
+          if (state.status == SearchStatus.loading) {
+            return const ProductGridShimmer(itemCount: 6);
+          }
+
+          if (state.status == SearchStatus.loaded) {
+            if (state.results.isEmpty) {
+              return const EmptyStateWidget(
+                icon: Icons.search_off,
+                title: 'Not Found',
+                subtitle:
+                    'Sorry, the keyword you entered cannot be found. Please try another keyword.',
+              );
+            }
+            return _buildResults(state);
+          }
+
+          if (state.status == SearchStatus.error) {
+            return EmptyStateWidget(
+              title: 'Search failed',
+              subtitle: state.errorMessage,
+              buttonText: 'Retry',
+              onButtonPressed: () =>
+                  context.read<SearchCubit>().search(state.query),
+            );
+          }
+
+          // Initial state - show recent searches
+          return _buildRecentSearches(state);
+        },
+      ),
+    );
+  }
+
+  Widget _buildSearchField() {
+    return Container(
+      height: 42,
+      margin: const EdgeInsets.only(right: 16),
+      decoration: BoxDecoration(
+        color: AppColors.surface,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: TextField(
+        controller: _searchController,
+        focusNode: _focusNode,
+        onChanged: _onSearchChanged,
+        onSubmitted: _onSearchSubmitted,
+        textInputAction: TextInputAction.search,
+        decoration: InputDecoration(
+          hintText: AppStrings.searchHint,
+          hintStyle: const TextStyle(
+            color: AppColors.textHint,
+            fontSize: 14,
+          ),
+          prefixIcon: const Icon(
+            Icons.search,
+            color: AppColors.textHint,
+            size: 20,
+          ),
+          suffixIcon: _searchController.text.isNotEmpty
+              ? IconButton(
+                  icon: const Icon(Icons.close, size: 18),
+                  onPressed: () {
+                    _searchController.clear();
+                    context.read<SearchCubit>().updateSuggestions('');
+                    _focusNode.requestFocus();
+                  },
+                )
+              : null,
+          border: InputBorder.none,
+          contentPadding: const EdgeInsets.symmetric(vertical: 10),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRecentSearches(SearchState state) {
+    if (state.recentSearches.isEmpty) {
+      return const EmptyStateWidget(
+        icon: Icons.history,
+        title: 'Search for products',
+        subtitle: 'Find your favorite African groceries',
+      );
+    }
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Recent Searches',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            GestureDetector(
+              onTap: () => context.read<SearchCubit>().clearRecentSearches(),
+              child: const Text(
+                'Clear All',
+                style: TextStyle(
+                  color: AppColors.primary,
+                  fontWeight: FontWeight.w500,
+                  fontSize: 13,
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        ...state.recentSearches.map((query) => ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: const Icon(
+                Icons.history,
+                color: AppColors.textHint,
+                size: 20,
+              ),
+              title: Text(query, style: const TextStyle(fontSize: 14)),
+              trailing: IconButton(
+                icon: const Icon(Icons.close, size: 16),
+                onPressed: () =>
+                    context.read<SearchCubit>().removeRecentSearch(query),
+              ),
+              onTap: () {
+                _searchController.text = query;
+                _onSearchSubmitted(query);
+              },
+            )),
+      ],
+    );
+  }
+
+  Widget _buildSuggestions(SearchState state) {
+    return ListView.builder(
+      itemCount: state.suggestions.length,
+      itemBuilder: (context, index) {
+        final suggestion = state.suggestions[index];
+        return ListTile(
+          leading: const Icon(Icons.search, color: AppColors.textHint, size: 20),
+          title: Text(suggestion, style: const TextStyle(fontSize: 14)),
+          trailing: const Icon(
+            Icons.north_west,
+            color: AppColors.textHint,
+            size: 16,
+          ),
+          onTap: () {
+            _searchController.text = suggestion;
+            _onSearchSubmitted(suggestion);
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildResults(SearchState state) {
+    return GridView.builder(
+      controller: _scrollController,
+      padding: const EdgeInsets.all(16),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        childAspectRatio: 0.68,
+        crossAxisSpacing: 12,
+        mainAxisSpacing: 12,
+      ),
+      itemCount: state.results.length,
+      itemBuilder: (context, index) {
+        final product = state.results[index];
+        return ProductCard(
+          id: product.id,
+          name: product.name,
+          imageUrl: product.imageUrl,
+          price: product.price,
+          originalPrice: product.originalPrice,
+          rating: product.rating,
+          reviewCount: product.reviewCount,
+          discountPercent: product.discountPercent,
+          onTap: () => context.push('/product/${product.id}'),
+          onAddToCart: () {},
+          onWishlistToggle: () {},
+        );
+      },
     );
   }
 }

--- a/lib/features/categories/presentation/widgets/empty_state_widget.dart
+++ b/lib/features/categories/presentation/widgets/empty_state_widget.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import '../../../../core/constants/app_colors.dart';
+
+class EmptyStateWidget extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String? subtitle;
+  final String? buttonText;
+  final VoidCallback? onButtonPressed;
+
+  const EmptyStateWidget({
+    super.key,
+    this.icon = Icons.search_off,
+    this.title = 'Not Found',
+    this.subtitle,
+    this.buttonText,
+    this.onButtonPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              width: 100,
+              height: 100,
+              decoration: BoxDecoration(
+                color: AppColors.surface,
+                shape: BoxShape.circle,
+              ),
+              child: Icon(icon, size: 48, color: AppColors.textHint),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              title,
+              style: const TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.w600,
+                color: AppColors.textPrimary,
+              ),
+            ),
+            if (subtitle != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                subtitle!,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontSize: 14,
+                  color: AppColors.textSecondary,
+                ),
+              ),
+            ],
+            if (buttonText != null && onButtonPressed != null) ...[
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: onButtonPressed,
+                child: Text(buttonText!),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Categories grid screen with 3-column layout, colored icons, and shimmer loading
- Product listing with sort chips (All/Popular/Newest/Price), grid/list toggle, infinite scroll pagination
- Search screen with debounced auto-complete suggestions, recent searches (persisted via SharedPreferences), and "Not Found" empty state
- Full Clean Architecture: mock & remote datasources, repository, cubits with proper state management
- Reusable EmptyStateWidget for empty/error states across the app

## Test plan
- [ ] Categories screen shows 12 category items in a 3-column grid
- [ ] Tapping a category navigates to product listing with correct name
- [ ] Sort chips filter products (All, Popular, Newest, Price Low/High)
- [ ] Grid/List view toggle switches layout
- [ ] Scrolling to bottom loads more products (pagination)
- [ ] Search bar auto-completes with debounced suggestions
- [ ] Submitting search shows results or "Not Found" empty state
- [ ] Recent searches persist across search screen opens
- [ ] Clear All removes recent search history

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)