### PR TITLE
feat: implement Store Listing & Store Detail with tabs

### DIFF
--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -24,6 +24,10 @@ import '../../features/cart/data/repositories/cart_repository_impl.dart';
 import '../../features/cart/domain/repositories/cart_repository.dart';
 import '../../features/cart/presentation/cubit/cart_cubit.dart';
 import '../../features/cart/presentation/cubit/checkout_cubit.dart';
+import '../../features/store/data/datasources/store_mock_datasource.dart';
+import '../../features/store/data/repositories/store_repository_impl.dart';
+import '../../features/store/domain/repositories/store_repository.dart';
+import '../../features/store/presentation/cubit/store_list_cubit.dart';
 
 final getIt = GetIt.instance;
 
@@ -99,5 +103,16 @@ Future<void> configureDependencies() async {
   );
   getIt.registerLazySingleton<CheckoutCubit>(
     () => CheckoutCubit(getIt<CartRepository>()),
+  );
+
+  // Store
+  getIt.registerLazySingleton<StoreMockDatasource>(
+    () => StoreMockDatasource(),
+  );
+  getIt.registerLazySingleton<StoreRepository>(
+    () => StoreRepositoryImpl(getIt<StoreMockDatasource>()),
+  );
+  getIt.registerFactory<StoreListCubit>(
+    () => StoreListCubit(getIt<StoreRepository>()),
   );
 }

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -11,6 +11,9 @@ import '../../features/categories/presentation/cubit/search_cubit.dart';
 import '../../features/categories/domain/repositories/categories_repository.dart';
 import '../../features/cart/presentation/cubit/cart_cubit.dart';
 import '../../features/cart/presentation/cubit/checkout_cubit.dart';
+import '../../features/store/presentation/cubit/store_list_cubit.dart';
+import '../../features/store/presentation/cubit/store_detail_cubit.dart';
+import '../../features/store/domain/repositories/store_repository.dart';
 import '../../features/auth/presentation/screens/splash_screen.dart';
 import '../../features/auth/presentation/screens/sign_in_screen.dart';
 import '../../features/auth/presentation/screens/sign_up_screen.dart';
@@ -207,13 +210,23 @@ class AppRouter {
       // Store
       GoRoute(
         path: '/stores',
-        builder: (context, state) => const StoreListScreen(),
+        builder: (context, state) => BlocProvider(
+          create: (_) => getIt<StoreListCubit>()..loadStores(),
+          child: const StoreListScreen(),
+        ),
       ),
       GoRoute(
         path: '/store/:id',
-        builder: (context, state) => StoreDetailScreen(
-          storeId: state.pathParameters['id']!,
-        ),
+        builder: (context, state) {
+          final storeId = state.pathParameters['id']!;
+          return BlocProvider(
+            create: (_) => StoreDetailCubit(
+              repository: getIt<StoreRepository>(),
+              storeId: storeId,
+            )..loadStore(),
+            child: StoreDetailScreen(storeId: storeId),
+          );
+        },
       ),
 
       // Orders

--- a/lib/features/store/data/datasources/store_mock_datasource.dart
+++ b/lib/features/store/data/datasources/store_mock_datasource.dart
@@ -1,0 +1,177 @@
+import '../../../home/data/models/product_model.dart';
+import '../../../product_detail/data/models/review_model.dart';
+import '../models/store_model.dart';
+
+class StoreMockDatasource {
+  Future<List<StoreModel>> getStores({String? sort}) async {
+    await Future.delayed(const Duration(milliseconds: 600));
+    var stores = List<StoreModel>.from(_stores);
+    if (sort == 'popular') {
+      stores.sort((a, b) => (b.rating ?? 0).compareTo(a.rating ?? 0));
+    } else if (sort == 'newest') {
+      stores = stores.reversed.toList();
+    }
+    return stores;
+  }
+
+  Future<StoreModel> getStoreDetail(String id) async {
+    await Future.delayed(const Duration(milliseconds: 500));
+    return _stores.firstWhere((s) => s.id == id, orElse: () => _stores.first);
+  }
+
+  Future<List<ProductModel>> getStoreProducts(String storeId) async {
+    await Future.delayed(const Duration(milliseconds: 500));
+    return _storeProducts;
+  }
+
+  Future<List<ReviewModel>> getStoreReviews(String storeId) async {
+    await Future.delayed(const Duration(milliseconds: 400));
+    return _storeReviews;
+  }
+
+  static const _stores = [
+    StoreModel(
+      id: 'store1',
+      name: 'Ni-ana\'s Kitchen',
+      imageUrl: 'https://via.placeholder.com/100x100/4CAF50/FFFFFF?text=NK',
+      bannerUrl: 'https://via.placeholder.com/800x300/2E7D32/FFFFFF?text=Nianas+Kitchen',
+      rating: 4.9,
+      reviewCount: 256,
+      productCount: 48,
+      description:
+          'NIANAS is a family of talented people passionate about food. We believe in spreading love and happiness through food, and are inspired by Africa\'s culinary traditions. Our mission is to bring traditional African flavors to your doorstep. We make what\'s in season extraordinary, crafting products that celebrate the rich culinary heritage of Africa while meeting the highest quality standards.',
+      address: 'Online Mission, San Francisco, CA 94103',
+      phone: '(415) 555-0198',
+      socialLinks: {
+        'facebook': 'https://facebook.com',
+        'instagram': 'https://instagram.com',
+        'youtube': 'https://youtube.com',
+        'twitter': 'https://twitter.com',
+      },
+    ),
+    StoreModel(
+      id: 'store2',
+      name: 'Mama\'s Market',
+      imageUrl: 'https://via.placeholder.com/100x100/FFC107/212121?text=MM',
+      bannerUrl: 'https://via.placeholder.com/800x300/FFA000/FFFFFF?text=Mamas+Market',
+      rating: 4.7,
+      reviewCount: 189,
+      productCount: 35,
+      description: 'Your one-stop shop for authentic African meats and spices.',
+      address: '123 Market St, San Francisco, CA 94102',
+    ),
+    StoreModel(
+      id: 'store3',
+      name: 'FruiShop',
+      imageUrl: 'https://via.placeholder.com/100x100/8BC34A/FFFFFF?text=FS',
+      bannerUrl: 'https://via.placeholder.com/800x300/689F38/FFFFFF?text=FruiShop',
+      rating: 4.5,
+      reviewCount: 142,
+      productCount: 28,
+      description: 'Fresh tropical fruits delivered daily from African farms.',
+      address: '456 Fruit Ave, San Francisco, CA 94104',
+    ),
+    StoreModel(
+      id: 'store4',
+      name: 'African Spice House',
+      imageUrl: 'https://via.placeholder.com/100x100/FF5722/FFFFFF?text=ASH',
+      bannerUrl: 'https://via.placeholder.com/800x300/E64A19/FFFFFF?text=African+Spice+House',
+      rating: 4.8,
+      reviewCount: 312,
+      productCount: 62,
+      description: 'Premium spices and seasonings from across Africa.',
+      address: '789 Spice Blvd, San Francisco, CA 94105',
+    ),
+  ];
+
+  static const _storeProducts = [
+    ProductModel(
+      id: '1',
+      name: 'Beef Floss',
+      imageUrl: 'https://via.placeholder.com/300x300/FFCCBC/212121?text=Beef+Floss',
+      price: 59.00,
+      originalPrice: 75.00,
+      rating: 4.5,
+      reviewCount: 120,
+      discountPercent: 21,
+      unit: '250g',
+    ),
+    ProductModel(
+      id: '2',
+      name: 'Veal Rig',
+      imageUrl: 'https://via.placeholder.com/300x300/FFCCBC/212121?text=Veal+Rig',
+      price: 84.00,
+      originalPrice: 95.00,
+      rating: 4.3,
+      reviewCount: 89,
+      discountPercent: 12,
+      unit: '500g',
+    ),
+    ProductModel(
+      id: '3',
+      name: 'Beef Floss',
+      imageUrl: 'https://via.placeholder.com/300x300/FFCCBC/212121?text=Beef+Floss+2',
+      price: 59.00,
+      originalPrice: 69.00,
+      rating: 4.6,
+      reviewCount: 67,
+      discountPercent: 15,
+      unit: '250g',
+    ),
+    ProductModel(
+      id: '4',
+      name: 'Lamb Chops',
+      imageUrl: 'https://via.placeholder.com/300x300/FFCCBC/212121?text=Lamb+Chops',
+      price: 120.00,
+      originalPrice: 140.00,
+      rating: 4.8,
+      reviewCount: 203,
+      discountPercent: 14,
+      unit: '1kg',
+    ),
+    ProductModel(
+      id: '5',
+      name: 'Beef Steak',
+      imageUrl: 'https://via.placeholder.com/300x300/FFCCBC/212121?text=Beef+Steak',
+      price: 95.00,
+      rating: 4.7,
+      reviewCount: 156,
+      unit: '500g',
+    ),
+    ProductModel(
+      id: '6',
+      name: 'Suya Mix',
+      imageUrl: 'https://via.placeholder.com/300x300/FFCCBC/212121?text=Suya+Mix',
+      price: 25.00,
+      originalPrice: 30.00,
+      rating: 4.4,
+      reviewCount: 98,
+      discountPercent: 17,
+      unit: '200g',
+    ),
+  ];
+
+  static const _storeReviews = [
+    ReviewModel(
+      id: 'r1',
+      userName: 'Sampreeth Khattar',
+      rating: 5.0,
+      comment: 'The store was really, really hot! I usually take out all friends and family here.',
+      date: '2 days ago',
+    ),
+    ReviewModel(
+      id: 'r2',
+      userName: 'Oyin Billion',
+      rating: 4.5,
+      comment: 'Great cookware, its none in quality and cost effective.',
+      date: '1 week ago',
+    ),
+    ReviewModel(
+      id: 'r3',
+      userName: 'Tynisha Obiol',
+      rating: 5.0,
+      comment: 'Great food. They are beautiful. The family. They understand about quality, any customer service is awesome and trustworthy.',
+      date: '2 weeks ago',
+    ),
+  ];
+}

--- a/lib/features/store/data/models/store_model.dart
+++ b/lib/features/store/data/models/store_model.dart
@@ -1,0 +1,65 @@
+class StoreModel {
+  final String id;
+  final String name;
+  final String? imageUrl;
+  final String? bannerUrl;
+  final double? rating;
+  final int? reviewCount;
+  final int? productCount;
+  final String? description;
+  final String? address;
+  final String? phone;
+  final bool isFollowing;
+  final Map<String, String> socialLinks;
+
+  const StoreModel({
+    required this.id,
+    required this.name,
+    this.imageUrl,
+    this.bannerUrl,
+    this.rating,
+    this.reviewCount,
+    this.productCount,
+    this.description,
+    this.address,
+    this.phone,
+    this.isFollowing = false,
+    this.socialLinks = const {},
+  });
+
+  StoreModel copyWith({bool? isFollowing}) {
+    return StoreModel(
+      id: id,
+      name: name,
+      imageUrl: imageUrl,
+      bannerUrl: bannerUrl,
+      rating: rating,
+      reviewCount: reviewCount,
+      productCount: productCount,
+      description: description,
+      address: address,
+      phone: phone,
+      isFollowing: isFollowing ?? this.isFollowing,
+      socialLinks: socialLinks,
+    );
+  }
+
+  factory StoreModel.fromJson(Map<String, dynamic> json) {
+    return StoreModel(
+      id: json['id']?.toString() ?? '',
+      name: json['name'] as String? ?? '',
+      imageUrl: json['image_url'] as String?,
+      bannerUrl: json['banner_url'] as String?,
+      rating: (json['rating'] as num?)?.toDouble(),
+      reviewCount: json['review_count'] as int?,
+      productCount: json['product_count'] as int?,
+      description: json['description'] as String?,
+      address: json['address'] as String?,
+      phone: json['phone'] as String?,
+      isFollowing: json['is_following'] as bool? ?? false,
+      socialLinks: (json['social_links'] as Map<String, dynamic>?)
+              ?.map((k, v) => MapEntry(k, v.toString())) ??
+          {},
+    );
+  }
+}

--- a/lib/features/store/data/repositories/store_repository_impl.dart
+++ b/lib/features/store/data/repositories/store_repository_impl.dart
@@ -1,0 +1,53 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/api/api_exceptions.dart';
+import '../../../home/data/models/product_model.dart';
+import '../../../product_detail/data/models/review_model.dart';
+import '../../domain/repositories/store_repository.dart';
+import '../datasources/store_mock_datasource.dart';
+import '../models/store_model.dart';
+
+class StoreRepositoryImpl implements StoreRepository {
+  final StoreMockDatasource _mockDatasource;
+
+  StoreRepositoryImpl(this._mockDatasource);
+
+  @override
+  Future<Either<ApiException, List<StoreModel>>> getStores({String? sort}) async {
+    try {
+      final stores = await _mockDatasource.getStores(sort: sort);
+      return Right(stores);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+
+  @override
+  Future<Either<ApiException, StoreModel>> getStoreDetail(String id) async {
+    try {
+      final store = await _mockDatasource.getStoreDetail(id);
+      return Right(store);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+
+  @override
+  Future<Either<ApiException, List<ProductModel>>> getStoreProducts(String storeId) async {
+    try {
+      final products = await _mockDatasource.getStoreProducts(storeId);
+      return Right(products);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+
+  @override
+  Future<Either<ApiException, List<ReviewModel>>> getStoreReviews(String storeId) async {
+    try {
+      final reviews = await _mockDatasource.getStoreReviews(storeId);
+      return Right(reviews);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+}

--- a/lib/features/store/domain/repositories/store_repository.dart
+++ b/lib/features/store/domain/repositories/store_repository.dart
@@ -1,0 +1,12 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/api/api_exceptions.dart';
+import '../../../home/data/models/product_model.dart';
+import '../../../product_detail/data/models/review_model.dart';
+import '../../data/models/store_model.dart';
+
+abstract class StoreRepository {
+  Future<Either<ApiException, List<StoreModel>>> getStores({String? sort});
+  Future<Either<ApiException, StoreModel>> getStoreDetail(String id);
+  Future<Either<ApiException, List<ProductModel>>> getStoreProducts(String storeId);
+  Future<Either<ApiException, List<ReviewModel>>> getStoreReviews(String storeId);
+}

--- a/lib/features/store/presentation/cubit/store_detail_cubit.dart
+++ b/lib/features/store/presentation/cubit/store_detail_cubit.dart
@@ -1,0 +1,64 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../home/data/models/product_model.dart';
+import '../../../product_detail/data/models/review_model.dart';
+import '../../data/models/store_model.dart';
+import '../../domain/repositories/store_repository.dart';
+import 'store_detail_state.dart';
+
+class StoreDetailCubit extends Cubit<StoreDetailState> {
+  final StoreRepository _repository;
+  final String storeId;
+
+  StoreDetailCubit({
+    required StoreRepository repository,
+    required this.storeId,
+  })  : _repository = repository,
+        super(const StoreDetailState());
+
+  Future<void> loadStore() async {
+    emit(state.copyWith(status: StoreDetailStatus.loading));
+
+    final storeFuture = _repository.getStoreDetail(storeId);
+    final productsFuture = _repository.getStoreProducts(storeId);
+    final reviewsFuture = _repository.getStoreReviews(storeId);
+
+    final storeResult = await storeFuture;
+    final productsResult = await productsFuture;
+    final reviewsResult = await reviewsFuture;
+
+    String? error;
+
+    storeResult.fold(
+      (e) => error = e.message,
+      (StoreModel store) => emit(state.copyWith(
+        store: store,
+        isFollowing: store.isFollowing,
+      )),
+    );
+
+    productsResult.fold(
+      (e) {},
+      (List<ProductModel> products) =>
+          emit(state.copyWith(products: products)),
+    );
+
+    reviewsResult.fold(
+      (e) {},
+      (List<ReviewModel> reviews) =>
+          emit(state.copyWith(reviews: reviews)),
+    );
+
+    if (error != null) {
+      emit(state.copyWith(
+        status: StoreDetailStatus.error,
+        errorMessage: error,
+      ));
+    } else {
+      emit(state.copyWith(status: StoreDetailStatus.loaded));
+    }
+  }
+
+  void toggleFollow() {
+    emit(state.copyWith(isFollowing: !state.isFollowing));
+  }
+}

--- a/lib/features/store/presentation/cubit/store_detail_state.dart
+++ b/lib/features/store/presentation/cubit/store_detail_state.dart
@@ -1,0 +1,41 @@
+import '../../../home/data/models/product_model.dart';
+import '../../../product_detail/data/models/review_model.dart';
+import '../../data/models/store_model.dart';
+
+enum StoreDetailStatus { initial, loading, loaded, error }
+
+class StoreDetailState {
+  final StoreDetailStatus status;
+  final StoreModel? store;
+  final List<ProductModel> products;
+  final List<ReviewModel> reviews;
+  final bool isFollowing;
+  final String? errorMessage;
+
+  const StoreDetailState({
+    this.status = StoreDetailStatus.initial,
+    this.store,
+    this.products = const [],
+    this.reviews = const [],
+    this.isFollowing = false,
+    this.errorMessage,
+  });
+
+  StoreDetailState copyWith({
+    StoreDetailStatus? status,
+    StoreModel? store,
+    List<ProductModel>? products,
+    List<ReviewModel>? reviews,
+    bool? isFollowing,
+    String? errorMessage,
+  }) {
+    return StoreDetailState(
+      status: status ?? this.status,
+      store: store ?? this.store,
+      products: products ?? this.products,
+      reviews: reviews ?? this.reviews,
+      isFollowing: isFollowing ?? this.isFollowing,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+}

--- a/lib/features/store/presentation/cubit/store_list_cubit.dart
+++ b/lib/features/store/presentation/cubit/store_list_cubit.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../domain/repositories/store_repository.dart';
+import 'store_list_state.dart';
+
+class StoreListCubit extends Cubit<StoreListState> {
+  final StoreRepository _repository;
+
+  StoreListCubit(this._repository) : super(const StoreListState());
+
+  Future<void> loadStores() async {
+    emit(state.copyWith(status: StoreListStatus.loading));
+
+    final result = await _repository.getStores(sort: state.activeSort);
+
+    result.fold(
+      (error) => emit(state.copyWith(
+        status: StoreListStatus.error,
+        errorMessage: error.message,
+      )),
+      (stores) => emit(state.copyWith(
+        status: StoreListStatus.loaded,
+        stores: stores,
+      )),
+    );
+  }
+
+  Future<void> changeSort(String? sort) async {
+    emit(state.copyWith(activeSort: sort));
+    await loadStores();
+  }
+}

--- a/lib/features/store/presentation/cubit/store_list_state.dart
+++ b/lib/features/store/presentation/cubit/store_list_state.dart
@@ -1,0 +1,31 @@
+import '../../data/models/store_model.dart';
+
+enum StoreListStatus { initial, loading, loaded, error }
+
+class StoreListState {
+  final StoreListStatus status;
+  final List<StoreModel> stores;
+  final String? activeSort;
+  final String? errorMessage;
+
+  const StoreListState({
+    this.status = StoreListStatus.initial,
+    this.stores = const [],
+    this.activeSort,
+    this.errorMessage,
+  });
+
+  StoreListState copyWith({
+    StoreListStatus? status,
+    List<StoreModel>? stores,
+    String? activeSort,
+    String? errorMessage,
+  }) {
+    return StoreListState(
+      status: status ?? this.status,
+      stores: stores ?? this.stores,
+      activeSort: activeSort ?? this.activeSort,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+}

--- a/lib/features/store/presentation/screens/store_detail_screen.dart
+++ b/lib/features/store/presentation/screens/store_detail_screen.dart
@@ -1,4 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/app_strings.dart';
+import '../../../../core/widgets/app_button.dart';
+import '../../../../core/widgets/loading_shimmer.dart';
+import '../../../../core/widgets/product_card.dart';
+import '../../../product_detail/data/models/review_model.dart';
+import '../cubit/store_detail_cubit.dart';
+import '../cubit/store_detail_state.dart';
 
 class StoreDetailScreen extends StatelessWidget {
   final String storeId;
@@ -7,9 +18,569 @@ class StoreDetailScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Store')),
-      body: Center(child: Text('Store \$storeId')),
+    return BlocBuilder<StoreDetailCubit, StoreDetailState>(
+      builder: (context, state) {
+        if (state.status == StoreDetailStatus.loading ||
+            state.status == StoreDetailStatus.initial) {
+          return Scaffold(
+            appBar: AppBar(),
+            body: const Center(
+              child: CircularProgressIndicator(color: AppColors.primary),
+            ),
+          );
+        }
+
+        if (state.status == StoreDetailStatus.error || state.store == null) {
+          return Scaffold(
+            appBar: AppBar(),
+            body: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Text(state.errorMessage ?? 'Failed to load store'),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () =>
+                        context.read<StoreDetailCubit>().loadStore(),
+                    child: const Text('Retry'),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+
+        final store = state.store!;
+
+        return DefaultTabController(
+          length: 3,
+          child: Scaffold(
+            body: NestedScrollView(
+              headerSliverBuilder: (context, innerBoxIsScrolled) => [
+                // Banner
+                SliverAppBar(
+                  expandedHeight: 200,
+                  pinned: true,
+                  leading: IconButton(
+                    icon: const CircleAvatar(
+                      backgroundColor: AppColors.white,
+                      radius: 16,
+                      child: Icon(Icons.arrow_back_ios_new,
+                          size: 16, color: AppColors.textPrimary),
+                    ),
+                    onPressed: () => context.pop(),
+                  ),
+                  flexibleSpace: FlexibleSpaceBar(
+                    background: CachedNetworkImage(
+                      imageUrl: store.bannerUrl ?? '',
+                      fit: BoxFit.cover,
+                      errorWidget: (c, u, e) => Container(
+                        color: AppColors.primaryDark,
+                      ),
+                    ),
+                  ),
+                ),
+                // Store info header
+                SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      children: [
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(12),
+                          child: CachedNetworkImage(
+                            imageUrl: store.imageUrl ?? '',
+                            width: 56,
+                            height: 56,
+                            fit: BoxFit.cover,
+                            errorWidget: (c, u, e) => Container(
+                              width: 56,
+                              height: 56,
+                              color: AppColors.primaryLight,
+                              child: const Icon(Icons.store,
+                                  color: AppColors.primaryDark),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                store.name,
+                                style: const TextStyle(
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                              Row(
+                                children: [
+                                  const Icon(Icons.star,
+                                      size: 14, color: AppColors.ratingStar),
+                                  const SizedBox(width: 2),
+                                  Text(
+                                    '${store.rating?.toStringAsFixed(1) ?? "0.0"} (${store.reviewCount ?? 0})',
+                                    style: const TextStyle(
+                                      fontSize: 12,
+                                      color: AppColors.textSecondary,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
+                        ),
+                        SizedBox(
+                          height: 36,
+                          child: AppButton(
+                            text: state.isFollowing
+                                ? AppStrings.following
+                                : AppStrings.follow,
+                            width: 100,
+                            height: 36,
+                            isOutlined: !state.isFollowing,
+                            onPressed: () => context
+                                .read<StoreDetailCubit>()
+                                .toggleFollow(),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                // Tabs
+                const SliverPersistentHeader(
+                  pinned: true,
+                  delegate: _TabBarDelegate(),
+                ),
+              ],
+              body: TabBarView(
+                children: [
+                  _ProductsTab(state: state),
+                  _ReviewsTab(state: state),
+                  _ContactTab(state: state),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _TabBarDelegate extends SliverPersistentHeaderDelegate {
+  const _TabBarDelegate();
+
+  @override
+  double get minExtent => 48;
+  @override
+  double get maxExtent => 48;
+
+  @override
+  Widget build(
+    BuildContext context,
+    double shrinkOffset,
+    bool overlapsContent,
+  ) {
+    return Container(
+      color: AppColors.white,
+      child: const TabBar(
+        labelColor: AppColors.primary,
+        unselectedLabelColor: AppColors.textSecondary,
+        indicatorColor: AppColors.primary,
+        tabs: [
+          Tab(text: 'Products'),
+          Tab(text: AppStrings.reviews),
+          Tab(text: AppStrings.contact),
+        ],
+      ),
+    );
+  }
+
+  @override
+  bool shouldRebuild(covariant SliverPersistentHeaderDelegate oldDelegate) =>
+      false;
+}
+
+class _ProductsTab extends StatelessWidget {
+  final StoreDetailState state;
+
+  const _ProductsTab({required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    final store = state.store!;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // About Store
+          Text(AppStrings.aboutStore,
+              style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 8),
+          Text(
+            store.description ?? '',
+            style: const TextStyle(
+              fontSize: 13,
+              color: AppColors.textSecondary,
+              height: 1.5,
+            ),
+          ),
+          const SizedBox(height: 20),
+          // Popular Categories chips
+          Text('Popular Categories',
+              style: Theme.of(context).textTheme.titleSmall),
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: ['Best Selling', 'Food Supplies', 'Others', 'New Arrival']
+                .map((c) => Chip(
+                      label: Text(c, style: const TextStyle(fontSize: 12)),
+                      backgroundColor: AppColors.surface,
+                      side: BorderSide.none,
+                    ))
+                .toList(),
+          ),
+          const SizedBox(height: 20),
+          // All Products
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(AppStrings.allProducts,
+                  style: Theme.of(context).textTheme.titleSmall),
+              const Text(
+                AppStrings.seeAll,
+                style: TextStyle(
+                  color: AppColors.primary,
+                  fontWeight: FontWeight.w500,
+                  fontSize: 13,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          state.products.isEmpty
+              ? const LoadingShimmer(height: 200)
+              : GridView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  gridDelegate:
+                      const SliverGridDelegateWithFixedCrossAxisCount(
+                    crossAxisCount: 2,
+                    childAspectRatio: 0.68,
+                    crossAxisSpacing: 12,
+                    mainAxisSpacing: 12,
+                  ),
+                  itemCount: state.products.length,
+                  itemBuilder: (context, index) {
+                    final product = state.products[index];
+                    return ProductCard(
+                      id: product.id,
+                      name: product.name,
+                      imageUrl: product.imageUrl,
+                      price: product.price,
+                      originalPrice: product.originalPrice,
+                      rating: product.rating,
+                      reviewCount: product.reviewCount,
+                      discountPercent: product.discountPercent,
+                      onTap: () =>
+                          context.push('/product/${product.id}'),
+                    );
+                  },
+                ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ReviewsTab extends StatelessWidget {
+  final StoreDetailState state;
+
+  const _ReviewsTab({required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    final store = state.store!;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Rating summary
+          Row(
+            children: [
+              Column(
+                children: [
+                  Text(
+                    store.rating?.toStringAsFixed(1) ?? '0.0',
+                    style: const TextStyle(
+                      fontSize: 40,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  Text(
+                    '/5',
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: AppColors.textSecondary,
+                    ),
+                  ),
+                  Row(
+                    children: List.generate(5, (i) {
+                      return Icon(
+                        i < (store.rating?.round() ?? 0)
+                            ? Icons.star
+                            : Icons.star_border,
+                        color: AppColors.ratingStar,
+                        size: 16,
+                      );
+                    }),
+                  ),
+                ],
+              ),
+              const SizedBox(width: 24),
+              Expanded(child: _buildRatingBars(state.reviews)),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'User Reviews',
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const Icon(Icons.filter_list, color: AppColors.textSecondary),
+            ],
+          ),
+          const SizedBox(height: 12),
+          ...state.reviews.map((r) => _ReviewCard(review: r)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRatingBars(List<ReviewModel> reviews) {
+    final dist = <int, int>{1: 0, 2: 0, 3: 0, 4: 0, 5: 0};
+    for (final r in reviews) {
+      dist[r.rating.round().clamp(1, 5)] =
+          (dist[r.rating.round().clamp(1, 5)] ?? 0) + 1;
+    }
+    final total = reviews.length;
+
+    return Column(
+      children: List.generate(5, (i) {
+        final stars = 5 - i;
+        final count = dist[stars] ?? 0;
+        final ratio = total > 0 ? count / total : 0.0;
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 2),
+          child: Row(
+            children: [
+              Text('$stars', style: const TextStyle(fontSize: 12)),
+              const SizedBox(width: 4),
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: ratio,
+                    backgroundColor: AppColors.surface,
+                    color: AppColors.ratingStar,
+                    minHeight: 6,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      }),
+    );
+  }
+}
+
+class _ReviewCard extends StatelessWidget {
+  final ReviewModel review;
+
+  const _ReviewCard({required this.review});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              CircleAvatar(
+                radius: 18,
+                backgroundColor: AppColors.primaryLight,
+                child: Text(
+                  review.userName.isNotEmpty
+                      ? review.userName[0].toUpperCase()
+                      : '?',
+                  style: const TextStyle(
+                    color: AppColors.primaryDark,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      review.userName,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w600,
+                        fontSize: 13,
+                      ),
+                    ),
+                    Text(
+                      review.date,
+                      style: const TextStyle(
+                        fontSize: 11,
+                        color: AppColors.textHint,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Row(
+                children: List.generate(5, (i) {
+                  return Icon(
+                    i < review.rating.round()
+                        ? Icons.star
+                        : Icons.star_border,
+                    color: AppColors.ratingStar,
+                    size: 14,
+                  );
+                }),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            review.comment,
+            style: const TextStyle(
+              fontSize: 13,
+              color: AppColors.textSecondary,
+              height: 1.4,
+            ),
+          ),
+          const Divider(height: 24),
+        ],
+      ),
+    );
+  }
+}
+
+class _ContactTab extends StatelessWidget {
+  final StoreDetailState state;
+
+  const _ContactTab({required this.state});
+
+  @override
+  Widget build(BuildContext context) {
+    final store = state.store!;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Map placeholder
+          Container(
+            height: 200,
+            decoration: BoxDecoration(
+              color: AppColors.surface,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: const Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.map, size: 48, color: AppColors.textHint),
+                  SizedBox(height: 8),
+                  Text(
+                    'Map View',
+                    style: TextStyle(color: AppColors.textSecondary),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          if (store.address != null) ...[
+            Row(
+              children: [
+                const Icon(Icons.location_on,
+                    size: 18, color: AppColors.primary),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    store.address!,
+                    style: const TextStyle(
+                      fontSize: 14,
+                      color: AppColors.textSecondary,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 24),
+          ],
+          // Follow
+          Text(AppStrings.follow,
+              style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 12),
+          // Social links
+          if (store.socialLinks.isNotEmpty)
+            Row(
+              children: store.socialLinks.entries.map((entry) {
+                IconData icon;
+                Color color;
+                switch (entry.key) {
+                  case 'facebook':
+                    icon = Icons.facebook;
+                    color = const Color(0xFF1877F2);
+                  case 'instagram':
+                    icon = Icons.camera_alt;
+                    color = const Color(0xFFE4405F);
+                  case 'youtube':
+                    icon = Icons.play_circle_fill;
+                    color = const Color(0xFFFF0000);
+                  case 'twitter':
+                    icon = Icons.alternate_email;
+                    color = const Color(0xFF1DA1F2);
+                  default:
+                    icon = Icons.link;
+                    color = AppColors.primary;
+                }
+                return Padding(
+                  padding: const EdgeInsets.only(right: 12),
+                  child: Container(
+                    width: 40,
+                    height: 40,
+                    decoration: BoxDecoration(
+                      color: color,
+                      shape: BoxShape.circle,
+                    ),
+                    child: Icon(icon, color: AppColors.white, size: 20),
+                  ),
+                );
+              }).toList(),
+            ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/store/presentation/screens/store_list_screen.dart
+++ b/lib/features/store/presentation/screens/store_list_screen.dart
@@ -1,13 +1,284 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/app_strings.dart';
+import '../../../../core/widgets/loading_shimmer.dart';
+import '../../data/models/store_model.dart';
+import '../cubit/store_list_cubit.dart';
+import '../cubit/store_list_state.dart';
 
 class StoreListScreen extends StatelessWidget {
   const StoreListScreen({super.key});
 
+  static const _categoryIcons = <String, IconData>{
+    'grocery': Icons.shopping_basket,
+    'meats': Icons.restaurant,
+    'fish': Icons.set_meal,
+    'drinks': Icons.local_drink,
+    'bakery': Icons.bakery_dining,
+    'fruits': Icons.apple,
+    'poultry': Icons.egg,
+    'sweets': Icons.cake,
+    'noodles': Icons.ramen_dining,
+    'frozen': Icons.ac_unit,
+    'others': Icons.more_horiz,
+    'african': Icons.public,
+  };
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Store')),
-      body: const Center(child: Text('Store')),
+      appBar: AppBar(
+        title: const Text(AppStrings.store),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios, size: 20),
+          onPressed: () => context.pop(),
+        ),
+        actions: [
+          IconButton(icon: const Icon(Icons.search), onPressed: () {}),
+        ],
+      ),
+      body: BlocBuilder<StoreListCubit, StoreListState>(
+        builder: (context, state) {
+          return Column(
+            children: [
+              // Sort tabs
+              _buildSortTabs(context, state),
+              // Content
+              Expanded(
+                child: state.status == StoreListStatus.loading
+                    ? _buildShimmer()
+                    : state.status == StoreListStatus.error
+                        ? Center(child: Text(state.errorMessage ?? 'Error'))
+                        : _buildContent(context, state),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildSortTabs(BuildContext context, StoreListState state) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          children: [
+            _SortChip(
+              label: 'All stores',
+              isSelected: state.activeSort == null,
+              onTap: () => context.read<StoreListCubit>().changeSort(null),
+            ),
+            _SortChip(
+              label: 'Popular',
+              isSelected: state.activeSort == 'popular',
+              onTap: () =>
+                  context.read<StoreListCubit>().changeSort('popular'),
+            ),
+            _SortChip(
+              label: 'Newest',
+              isSelected: state.activeSort == 'newest',
+              onTap: () =>
+                  context.read<StoreListCubit>().changeSort('newest'),
+            ),
+            _SortChip(
+              label: 'Best Seller',
+              isSelected: state.activeSort == 'best_seller',
+              onTap: () =>
+                  context.read<StoreListCubit>().changeSort('best_seller'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, StoreListState state) {
+    return SingleChildScrollView(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Store list
+          ...state.stores.map((store) => _StoreCard(store: store)),
+          const SizedBox(height: 16),
+          // Category grid
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: GridView.count(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              crossAxisCount: 3,
+              childAspectRatio: 0.85,
+              crossAxisSpacing: 16,
+              mainAxisSpacing: 16,
+              children: _categoryIcons.entries.map((entry) {
+                return Column(
+                  children: [
+                    Container(
+                      width: 64,
+                      height: 64,
+                      decoration: BoxDecoration(
+                        color: AppColors.primaryLight,
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: Icon(
+                        entry.value,
+                        color: AppColors.primaryDark,
+                        size: 28,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      entry.key[0].toUpperCase() + entry.key.substring(1),
+                      style: const TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ],
+                );
+              }).toList(),
+            ),
+          ),
+          const SizedBox(height: 24),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildShimmer() {
+    return ListView.builder(
+      padding: const EdgeInsets.all(16),
+      itemCount: 4,
+      itemBuilder: (context, index) => Padding(
+        padding: const EdgeInsets.only(bottom: 12),
+        child: LoadingShimmer(height: 80, borderRadius: 12),
+      ),
+    );
+  }
+}
+
+class _StoreCard extends StatelessWidget {
+  final StoreModel store;
+
+  const _StoreCard({required this.store});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => context.push('/store/${store.id}'),
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: AppColors.white,
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [
+            BoxShadow(
+              color: AppColors.shadow.withValues(alpha: 0.08),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(10),
+              child: CachedNetworkImage(
+                imageUrl: store.imageUrl ?? '',
+                width: 56,
+                height: 56,
+                fit: BoxFit.cover,
+                errorWidget: (c, u, e) => Container(
+                  width: 56,
+                  height: 56,
+                  color: AppColors.primaryLight,
+                  child: const Icon(Icons.store, color: AppColors.primaryDark),
+                ),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    store.name,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.w600,
+                      fontSize: 15,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      const Icon(Icons.star, size: 14, color: AppColors.ratingStar),
+                      const SizedBox(width: 2),
+                      Text(
+                        store.rating?.toStringAsFixed(1) ?? '0.0',
+                        style: const TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                      Text(
+                        '  (${store.reviewCount ?? 0})',
+                        style: const TextStyle(
+                          fontSize: 12,
+                          color: AppColors.textHint,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const Icon(Icons.arrow_forward_ios, size: 16, color: AppColors.textHint),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SortChip extends StatelessWidget {
+  final String label;
+  final bool isSelected;
+  final VoidCallback onTap;
+
+  const _SortChip({
+    required this.label,
+    required this.isSelected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 8),
+      child: GestureDetector(
+        onTap: onTap,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          decoration: BoxDecoration(
+            color: isSelected ? AppColors.primary : AppColors.surface,
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 13,
+              fontWeight: FontWeight.w500,
+              color: isSelected ? AppColors.white : AppColors.textSecondary,
+            ),
+          ),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- Store listing with sort chips (All/Popular/Newest/Best Seller), store cards with rating, and category icon grid
- Store detail with banner header, logo, Follow/Unfollow button, and 3-tab layout:
  - Products tab: About Store description, Popular Categories chips, All Products 2-column grid
  - Reviews tab: rating summary (4.9/5) with star distribution bars, user review cards
  - Contact tab: map placeholder, address with icon, social media icons (Facebook, Instagram, YouTube, Twitter)
- Full Clean Architecture: StoreModel, mock datasource (4 stores), repository, cubits

## Test plan
- [ ] Store listing shows 4 stores with sort chip filtering
- [ ] Tapping store navigates to store detail
- [ ] Store detail shows banner, logo, name, rating
- [ ] Follow button toggles between Follow/Following
- [ ] Products tab shows About Store + product grid
- [ ] Reviews tab shows rating summary + review cards
- [ ] Contact tab shows map placeholder + address + social icons
- [ ] Tab navigation works smoothly

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)