### PR TITLE
feat: implement My Orders & Profile screens

### DIFF
--- a/lib/core/di/injection.dart
+++ b/lib/core/di/injection.dart
@@ -28,6 +28,10 @@ import '../../features/store/data/datasources/store_mock_datasource.dart';
 import '../../features/store/data/repositories/store_repository_impl.dart';
 import '../../features/store/domain/repositories/store_repository.dart';
 import '../../features/store/presentation/cubit/store_list_cubit.dart';
+import '../../features/orders/data/datasources/orders_mock_datasource.dart';
+import '../../features/orders/data/repositories/orders_repository_impl.dart';
+import '../../features/orders/domain/repositories/orders_repository.dart';
+import '../../features/orders/presentation/cubit/orders_cubit.dart';
 
 final getIt = GetIt.instance;
 
@@ -114,5 +118,16 @@ Future<void> configureDependencies() async {
   );
   getIt.registerFactory<StoreListCubit>(
     () => StoreListCubit(getIt<StoreRepository>()),
+  );
+
+  // Orders
+  getIt.registerLazySingleton<OrdersMockDatasource>(
+    () => OrdersMockDatasource(),
+  );
+  getIt.registerLazySingleton<OrdersRepository>(
+    () => OrdersRepositoryImpl(getIt<OrdersMockDatasource>()),
+  );
+  getIt.registerLazySingleton<OrdersCubit>(
+    () => OrdersCubit(getIt<OrdersRepository>()),
   );
 }

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -14,6 +14,7 @@ import '../../features/cart/presentation/cubit/checkout_cubit.dart';
 import '../../features/store/presentation/cubit/store_list_cubit.dart';
 import '../../features/store/presentation/cubit/store_detail_cubit.dart';
 import '../../features/store/domain/repositories/store_repository.dart';
+import '../../features/orders/presentation/cubit/orders_cubit.dart';
 import '../../features/auth/presentation/screens/splash_screen.dart';
 import '../../features/auth/presentation/screens/sign_in_screen.dart';
 import '../../features/auth/presentation/screens/sign_up_screen.dart';
@@ -232,18 +233,27 @@ class AppRouter {
       // Orders
       GoRoute(
         path: '/my-orders',
-        builder: (context, state) => const MyOrdersScreen(),
+        builder: (context, state) => BlocProvider.value(
+          value: getIt<OrdersCubit>()..loadOrders(),
+          child: const MyOrdersScreen(),
+        ),
       ),
       GoRoute(
         path: '/order/:id',
-        builder: (context, state) => OrderDetailScreen(
-          orderId: state.pathParameters['id']!,
+        builder: (context, state) => BlocProvider.value(
+          value: getIt<OrdersCubit>(),
+          child: OrderDetailScreen(
+            orderId: state.pathParameters['id']!,
+          ),
         ),
       ),
       GoRoute(
         path: '/track-order/:id',
-        builder: (context, state) => TrackOrderScreen(
-          orderId: state.pathParameters['id']!,
+        builder: (context, state) => BlocProvider.value(
+          value: getIt<OrdersCubit>(),
+          child: TrackOrderScreen(
+            orderId: state.pathParameters['id']!,
+          ),
         ),
       ),
 

--- a/lib/features/orders/data/datasources/orders_mock_datasource.dart
+++ b/lib/features/orders/data/datasources/orders_mock_datasource.dart
@@ -1,0 +1,91 @@
+import '../models/order_model.dart';
+import '../models/order_item_model.dart';
+
+class OrdersMockDatasource {
+  Future<List<OrderModel>> getOrders({String? status}) async {
+    await Future.delayed(const Duration(milliseconds: 600));
+    if (status == 'completed') return [_orders[2]];
+    if (status == 'cancelled') return [_orders[3]];
+    if (status == 'active') return [_orders[0], _orders[1]];
+    return _orders;
+  }
+
+  Future<OrderModel> getOrderDetail(String id) async {
+    await Future.delayed(const Duration(milliseconds: 400));
+    return _orders.firstWhere((o) => o.id == id, orElse: () => _orders.first);
+  }
+
+  static final _orders = [
+    const OrderModel(
+      id: 'ord1',
+      orderNumber: 'ORD-20260401001',
+      items: [
+        OrderItemModel(id: 'oi1', productId: '2', name: 'Chicken Sharma', imageUrl: 'https://via.placeholder.com/100x100/FFCCBC/212121?text=Chicken', price: 140.00, quantity: 2, variant: '1kg'),
+        OrderItemModel(id: 'oi2', productId: '5', name: 'Palm Oil', imageUrl: 'https://via.placeholder.com/100x100/FFE0B2/212121?text=Palm+Oil', price: 45.00, quantity: 1, variant: '1L'),
+      ],
+      subtotal: 325.00,
+      shipping: 0,
+      discount: 32.50,
+      total: 292.50,
+      status: OrderStatus.processing,
+      date: 'Apr 01, 2026',
+      address: '384 Westheimer Rd, San Francisco, CA 94102',
+      trackingSteps: [
+        TrackingStep(title: 'Order Placed', subtitle: 'Your order has been placed', date: 'Apr 01, 2026', isCompleted: true),
+        TrackingStep(title: 'Processing', subtitle: 'Your order is being prepared', date: 'Apr 01, 2026', isCompleted: true),
+        TrackingStep(title: 'Shipped', subtitle: 'Your order is on the way'),
+        TrackingStep(title: 'Delivered', subtitle: 'Your order has been delivered'),
+      ],
+    ),
+    const OrderModel(
+      id: 'ord2',
+      orderNumber: 'ORD-20260330002',
+      items: [
+        OrderItemModel(id: 'oi3', productId: '10', name: 'Suya Spice Mix', imageUrl: 'https://via.placeholder.com/100x100/FFCCBC/212121?text=Suya', price: 15.00, quantity: 3, variant: '200g'),
+      ],
+      subtotal: 45.00,
+      shipping: 10.00,
+      total: 55.00,
+      status: OrderStatus.shipped,
+      date: 'Mar 30, 2026',
+      address: '384 Westheimer Rd, San Francisco, CA 94102',
+      trackingSteps: [
+        TrackingStep(title: 'Order Placed', date: 'Mar 30, 2026', isCompleted: true),
+        TrackingStep(title: 'Processing', date: 'Mar 30, 2026', isCompleted: true),
+        TrackingStep(title: 'Shipped', subtitle: 'Out for delivery', date: 'Mar 31, 2026', isCompleted: true),
+        TrackingStep(title: 'Delivered'),
+      ],
+    ),
+    const OrderModel(
+      id: 'ord3',
+      orderNumber: 'ORD-20260325003',
+      items: [
+        OrderItemModel(id: 'oi4', productId: '6', name: 'Cassava Flour', imageUrl: 'https://via.placeholder.com/100x100/FFF9C4/212121?text=Cassava', price: 18.00, quantity: 2, variant: '1kg'),
+      ],
+      subtotal: 36.00,
+      shipping: 10.00,
+      total: 46.00,
+      status: OrderStatus.delivered,
+      date: 'Mar 25, 2026',
+      address: '384 Westheimer Rd, San Francisco, CA 94102',
+      trackingSteps: [
+        TrackingStep(title: 'Order Placed', date: 'Mar 25, 2026', isCompleted: true),
+        TrackingStep(title: 'Processing', date: 'Mar 25, 2026', isCompleted: true),
+        TrackingStep(title: 'Shipped', date: 'Mar 26, 2026', isCompleted: true),
+        TrackingStep(title: 'Delivered', date: 'Mar 27, 2026', isCompleted: true),
+      ],
+    ),
+    const OrderModel(
+      id: 'ord4',
+      orderNumber: 'ORD-20260320004',
+      items: [
+        OrderItemModel(id: 'oi5', productId: '9', name: 'Dried Stockfish', imageUrl: 'https://via.placeholder.com/100x100/FFCCBC/212121?text=Stockfish', price: 85.00, quantity: 1, variant: '500g'),
+      ],
+      subtotal: 85.00,
+      shipping: 0,
+      total: 85.00,
+      status: OrderStatus.cancelled,
+      date: 'Mar 20, 2026',
+    ),
+  ];
+}

--- a/lib/features/orders/data/models/order_item_model.dart
+++ b/lib/features/orders/data/models/order_item_model.dart
@@ -1,0 +1,33 @@
+class OrderItemModel {
+  final String id;
+  final String productId;
+  final String name;
+  final String imageUrl;
+  final double price;
+  final int quantity;
+  final String? variant;
+
+  const OrderItemModel({
+    required this.id,
+    required this.productId,
+    required this.name,
+    required this.imageUrl,
+    required this.price,
+    required this.quantity,
+    this.variant,
+  });
+
+  double get total => price * quantity;
+
+  factory OrderItemModel.fromJson(Map<String, dynamic> json) {
+    return OrderItemModel(
+      id: json['id']?.toString() ?? '',
+      productId: json['product_id']?.toString() ?? '',
+      name: json['name'] as String? ?? '',
+      imageUrl: json['image_url'] as String? ?? '',
+      price: (json['price'] as num?)?.toDouble() ?? 0,
+      quantity: json['quantity'] as int? ?? 1,
+      variant: json['variant'] as String?,
+    );
+  }
+}

--- a/lib/features/orders/data/models/order_model.dart
+++ b/lib/features/orders/data/models/order_model.dart
@@ -1,0 +1,92 @@
+import 'order_item_model.dart';
+
+enum OrderStatus { processing, shipped, delivered, cancelled }
+
+class OrderModel {
+  final String id;
+  final String orderNumber;
+  final List<OrderItemModel> items;
+  final double subtotal;
+  final double shipping;
+  final double discount;
+  final double total;
+  final OrderStatus status;
+  final String date;
+  final String? address;
+  final List<TrackingStep> trackingSteps;
+
+  const OrderModel({
+    required this.id,
+    required this.orderNumber,
+    required this.items,
+    required this.subtotal,
+    required this.shipping,
+    this.discount = 0,
+    required this.total,
+    required this.status,
+    required this.date,
+    this.address,
+    this.trackingSteps = const [],
+  });
+
+  String get statusLabel {
+    switch (status) {
+      case OrderStatus.processing:
+        return 'In Progress';
+      case OrderStatus.shipped:
+        return 'Shipped';
+      case OrderStatus.delivered:
+        return 'Delivered';
+      case OrderStatus.cancelled:
+        return 'Cancelled';
+    }
+  }
+
+  factory OrderModel.fromJson(Map<String, dynamic> json) {
+    return OrderModel(
+      id: json['id']?.toString() ?? '',
+      orderNumber: json['order_number'] as String? ?? '',
+      items: (json['items'] as List<dynamic>?)
+              ?.map((e) => OrderItemModel.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+      subtotal: (json['subtotal'] as num?)?.toDouble() ?? 0,
+      shipping: (json['shipping'] as num?)?.toDouble() ?? 0,
+      discount: (json['discount'] as num?)?.toDouble() ?? 0,
+      total: (json['total'] as num?)?.toDouble() ?? 0,
+      status: OrderStatus.values.firstWhere(
+        (s) => s.name == json['status'],
+        orElse: () => OrderStatus.processing,
+      ),
+      date: json['date'] as String? ?? '',
+      address: json['address'] as String?,
+      trackingSteps: (json['tracking_steps'] as List<dynamic>?)
+              ?.map((e) => TrackingStep.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
+    );
+  }
+}
+
+class TrackingStep {
+  final String title;
+  final String? subtitle;
+  final String? date;
+  final bool isCompleted;
+
+  const TrackingStep({
+    required this.title,
+    this.subtitle,
+    this.date,
+    this.isCompleted = false,
+  });
+
+  factory TrackingStep.fromJson(Map<String, dynamic> json) {
+    return TrackingStep(
+      title: json['title'] as String? ?? '',
+      subtitle: json['subtitle'] as String?,
+      date: json['date'] as String?,
+      isCompleted: json['is_completed'] as bool? ?? false,
+    );
+  }
+}

--- a/lib/features/orders/data/repositories/orders_repository_impl.dart
+++ b/lib/features/orders/data/repositories/orders_repository_impl.dart
@@ -1,0 +1,31 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/api/api_exceptions.dart';
+import '../../domain/repositories/orders_repository.dart';
+import '../datasources/orders_mock_datasource.dart';
+import '../models/order_model.dart';
+
+class OrdersRepositoryImpl implements OrdersRepository {
+  final OrdersMockDatasource _mockDatasource;
+
+  OrdersRepositoryImpl(this._mockDatasource);
+
+  @override
+  Future<Either<ApiException, List<OrderModel>>> getOrders({String? status}) async {
+    try {
+      final orders = await _mockDatasource.getOrders(status: status);
+      return Right(orders);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+
+  @override
+  Future<Either<ApiException, OrderModel>> getOrderDetail(String id) async {
+    try {
+      final order = await _mockDatasource.getOrderDetail(id);
+      return Right(order);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+}

--- a/lib/features/orders/domain/repositories/orders_repository.dart
+++ b/lib/features/orders/domain/repositories/orders_repository.dart
@@ -1,0 +1,8 @@
+import 'package:dartz/dartz.dart';
+import '../../../../core/api/api_exceptions.dart';
+import '../../data/models/order_model.dart';
+
+abstract class OrdersRepository {
+  Future<Either<ApiException, List<OrderModel>>> getOrders({String? status});
+  Future<Either<ApiException, OrderModel>> getOrderDetail(String id);
+}

--- a/lib/features/orders/presentation/cubit/orders_cubit.dart
+++ b/lib/features/orders/presentation/cubit/orders_cubit.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../domain/repositories/orders_repository.dart';
+import 'orders_state.dart';
+
+class OrdersCubit extends Cubit<OrdersState> {
+  final OrdersRepository _repository;
+
+  OrdersCubit(this._repository) : super(const OrdersState());
+
+  Future<void> loadOrders() async {
+    emit(state.copyWith(status: OrdersStatus.loading));
+
+    final result = await _repository.getOrders(status: state.activeTab);
+
+    result.fold(
+      (error) => emit(state.copyWith(
+        status: OrdersStatus.error,
+        errorMessage: error.message,
+      )),
+      (orders) => emit(state.copyWith(
+        status: OrdersStatus.loaded,
+        orders: orders,
+      )),
+    );
+  }
+
+  Future<void> changeTab(String tab) async {
+    emit(state.copyWith(activeTab: tab));
+    await loadOrders();
+  }
+}

--- a/lib/features/orders/presentation/cubit/orders_state.dart
+++ b/lib/features/orders/presentation/cubit/orders_state.dart
@@ -1,0 +1,31 @@
+import '../../data/models/order_model.dart';
+
+enum OrdersStatus { initial, loading, loaded, error }
+
+class OrdersState {
+  final OrdersStatus status;
+  final List<OrderModel> orders;
+  final String activeTab;
+  final String? errorMessage;
+
+  const OrdersState({
+    this.status = OrdersStatus.initial,
+    this.orders = const [],
+    this.activeTab = 'active',
+    this.errorMessage,
+  });
+
+  OrdersState copyWith({
+    OrdersStatus? status,
+    List<OrderModel>? orders,
+    String? activeTab,
+    String? errorMessage,
+  }) {
+    return OrdersState(
+      status: status ?? this.status,
+      orders: orders ?? this.orders,
+      activeTab: activeTab ?? this.activeTab,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+}

--- a/lib/features/orders/presentation/screens/my_orders_screen.dart
+++ b/lib/features/orders/presentation/screens/my_orders_screen.dart
@@ -1,13 +1,237 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/app_strings.dart';
+import '../../../../core/utils/extensions.dart';
+import '../../data/models/order_model.dart';
+import '../cubit/orders_cubit.dart';
+import '../cubit/orders_state.dart';
 
 class MyOrdersScreen extends StatelessWidget {
   const MyOrdersScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('My Orders')),
-      body: const Center(child: Text('My Orders')),
+    return DefaultTabController(
+      length: 3,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text(AppStrings.myOrders),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back_ios, size: 20),
+            onPressed: () => context.pop(),
+          ),
+          bottom: TabBar(
+            labelColor: AppColors.primary,
+            unselectedLabelColor: AppColors.textSecondary,
+            indicatorColor: AppColors.primary,
+            onTap: (index) {
+              final tabs = ['active', 'completed', 'cancelled'];
+              context.read<OrdersCubit>().changeTab(tabs[index]);
+            },
+            tabs: const [
+              Tab(text: 'Active'),
+              Tab(text: 'Completed'),
+              Tab(text: 'Cancelled'),
+            ],
+          ),
+        ),
+        body: BlocBuilder<OrdersCubit, OrdersState>(
+          builder: (context, state) {
+            if (state.status == OrdersStatus.loading) {
+              return const Center(
+                child: CircularProgressIndicator(color: AppColors.primary),
+              );
+            }
+
+            if (state.orders.isEmpty) {
+              return const Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.receipt_long_outlined,
+                        size: 64, color: AppColors.textHint),
+                    SizedBox(height: 16),
+                    Text('No orders yet',
+                        style: TextStyle(fontSize: 16, color: AppColors.textSecondary)),
+                  ],
+                ),
+              );
+            }
+
+            return ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: state.orders.length,
+              itemBuilder: (context, index) {
+                return _OrderCard(order: state.orders[index]);
+              },
+            );
+          },
+        ),
+      ),
     );
+  }
+}
+
+class _OrderCard extends StatelessWidget {
+  final OrderModel order;
+
+  const _OrderCard({required this.order});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => context.push('/order/${order.id}'),
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 12),
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: AppColors.white,
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [
+            BoxShadow(
+              color: AppColors.shadow.withValues(alpha: 0.08),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  order.orderNumber,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w600,
+                    fontSize: 14,
+                  ),
+                ),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: _statusColor(order.status).withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(12),
+                    border: Border.all(color: _statusColor(order.status)),
+                  ),
+                  child: Text(
+                    order.statusLabel,
+                    style: TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w500,
+                      color: _statusColor(order.status),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Text(
+              order.date,
+              style: const TextStyle(fontSize: 12, color: AppColors.textHint),
+            ),
+            const SizedBox(height: 12),
+            // Items preview
+            SizedBox(
+              height: 40,
+              child: Row(
+                children: [
+                  ...order.items.take(3).map((item) => Padding(
+                        padding: const EdgeInsets.only(right: 8),
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(6),
+                          child: CachedNetworkImage(
+                            imageUrl: item.imageUrl,
+                            width: 40,
+                            height: 40,
+                            fit: BoxFit.cover,
+                            errorWidget: (c, u, e) => Container(
+                              width: 40, height: 40,
+                              color: AppColors.surface,
+                              child: const Icon(Icons.image, size: 16, color: AppColors.textHint),
+                            ),
+                          ),
+                        ),
+                      )),
+                  if (order.items.length > 3)
+                    Container(
+                      width: 40,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        color: AppColors.surface,
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      child: Center(
+                        child: Text(
+                          '+${order.items.length - 3}',
+                          style: const TextStyle(
+                            fontSize: 12,
+                            fontWeight: FontWeight.w600,
+                            color: AppColors.textSecondary,
+                          ),
+                        ),
+                      ),
+                    ),
+                  const Spacer(),
+                  Text(
+                    order.total.toCurrency,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.w700,
+                      fontSize: 15,
+                      color: AppColors.primary,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                if (order.status == OrderStatus.processing ||
+                    order.status == OrderStatus.shipped)
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: () => context.push('/track-order/${order.id}'),
+                      child: const Text(AppStrings.trackOrder),
+                    ),
+                  ),
+                if (order.status == OrderStatus.delivered) ...[
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: () {},
+                      child: const Text(AppStrings.reOrder),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: () {},
+                      child: const Text(AppStrings.rateOrder),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Color _statusColor(OrderStatus status) {
+    switch (status) {
+      case OrderStatus.processing:
+        return AppColors.primary;
+      case OrderStatus.shipped:
+        return AppColors.info;
+      case OrderStatus.delivered:
+        return AppColors.success;
+      case OrderStatus.cancelled:
+        return AppColors.error;
+    }
   }
 }

--- a/lib/features/orders/presentation/screens/order_detail_screen.dart
+++ b/lib/features/orders/presentation/screens/order_detail_screen.dart
@@ -1,15 +1,209 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/app_strings.dart';
+import '../../../../core/utils/extensions.dart';
+import '../../data/models/order_model.dart';
+import '../cubit/orders_cubit.dart';
 
-class OrderDetailScreen extends StatelessWidget {
+class OrderDetailScreen extends StatefulWidget {
   final String orderId;
 
   const OrderDetailScreen({super.key, required this.orderId});
 
   @override
+  State<OrderDetailScreen> createState() => _OrderDetailScreenState();
+}
+
+class _OrderDetailScreenState extends State<OrderDetailScreen> {
+  OrderModel? _order;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadOrder();
+  }
+
+  void _loadOrder() {
+    final result = context.read<OrdersCubit>().state.orders
+        .where((o) => o.id == widget.orderId)
+        .firstOrNull;
+    if (result != null) {
+      setState(() => _order = result);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Order Detail')),
-      body: Center(child: Text('Order \$orderId')),
+      appBar: AppBar(
+        title: const Text('Order Detail'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios, size: 20),
+          onPressed: () => context.pop(),
+        ),
+      ),
+      body: _order == null
+          ? const Center(
+              child: CircularProgressIndicator(color: AppColors.primary))
+          : SingleChildScrollView(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Order info
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        _order!.orderNumber,
+                        style: const TextStyle(
+                          fontWeight: FontWeight.w700,
+                          fontSize: 16,
+                        ),
+                      ),
+                      Text(
+                        _order!.statusLabel,
+                        style: TextStyle(
+                          fontWeight: FontWeight.w600,
+                          color: _order!.status == OrderStatus.delivered
+                              ? AppColors.success
+                              : AppColors.primary,
+                        ),
+                      ),
+                    ],
+                  ),
+                  Text(
+                    _order!.date,
+                    style: const TextStyle(
+                        fontSize: 13, color: AppColors.textHint),
+                  ),
+                  const Divider(height: 24),
+                  // Items
+                  ..._order!.items.map((item) => Padding(
+                        padding: const EdgeInsets.only(bottom: 12),
+                        child: Row(
+                          children: [
+                            ClipRRect(
+                              borderRadius: BorderRadius.circular(8),
+                              child: CachedNetworkImage(
+                                imageUrl: item.imageUrl,
+                                width: 60,
+                                height: 60,
+                                fit: BoxFit.cover,
+                                errorWidget: (c, u, e) => Container(
+                                  width: 60,
+                                  height: 60,
+                                  color: AppColors.surface,
+                                ),
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment:
+                                    CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    item.name,
+                                    style: const TextStyle(
+                                        fontWeight: FontWeight.w500),
+                                  ),
+                                  if (item.variant != null)
+                                    Text(
+                                      item.variant!,
+                                      style: const TextStyle(
+                                        fontSize: 12,
+                                        color: AppColors.textSecondary,
+                                      ),
+                                    ),
+                                  Text(
+                                    'x${item.quantity}',
+                                    style: const TextStyle(
+                                      fontSize: 12,
+                                      color: AppColors.textHint,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                            Text(
+                              item.total.toCurrency,
+                              style: const TextStyle(
+                                fontWeight: FontWeight.w600,
+                                color: AppColors.primary,
+                              ),
+                            ),
+                          ],
+                        ),
+                      )),
+                  const Divider(height: 24),
+                  // Summary
+                  _row(AppStrings.subTotal, _order!.subtotal.toCurrency),
+                  const SizedBox(height: 8),
+                  _row(AppStrings.shipping, _order!.shipping.toCurrency),
+                  if (_order!.discount > 0) ...[
+                    const SizedBox(height: 8),
+                    _row(AppStrings.discount,
+                        '-${_order!.discount.toCurrency}',
+                        valueColor: AppColors.primary),
+                  ],
+                  const Divider(height: 24),
+                  _row(AppStrings.total, _order!.total.toCurrency,
+                      isBold: true),
+                  // Address
+                  if (_order!.address != null) ...[
+                    const Divider(height: 24),
+                    Text(AppStrings.shippingAddress,
+                        style: Theme.of(context).textTheme.titleSmall),
+                    const SizedBox(height: 8),
+                    Text(
+                      _order!.address!,
+                      style: const TextStyle(
+                        fontSize: 13,
+                        color: AppColors.textSecondary,
+                      ),
+                    ),
+                  ],
+                  // Track button
+                  if (_order!.status == OrderStatus.processing ||
+                      _order!.status == OrderStatus.shipped) ...[
+                    const SizedBox(height: 24),
+                    SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        onPressed: () =>
+                            context.push('/track-order/${_order!.id}'),
+                        child: const Text(AppStrings.trackOrder),
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+    );
+  }
+
+  Widget _row(String label, String value,
+      {bool isBold = false, Color? valueColor}) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(label,
+            style: TextStyle(
+              fontSize: isBold ? 16 : 14,
+              fontWeight: isBold ? FontWeight.w700 : FontWeight.w400,
+              color: AppColors.textSecondary,
+            )),
+        Text(value,
+            style: TextStyle(
+              fontSize: isBold ? 16 : 14,
+              fontWeight: isBold ? FontWeight.w700 : FontWeight.w500,
+              color: valueColor ?? AppColors.textPrimary,
+            )),
+      ],
     );
   }
 }

--- a/lib/features/orders/presentation/screens/track_order_screen.dart
+++ b/lib/features/orders/presentation/screens/track_order_screen.dart
@@ -1,4 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/app_strings.dart';
+import '../../data/models/order_model.dart';
+import '../cubit/orders_cubit.dart';
 
 class TrackOrderScreen extends StatelessWidget {
   final String orderId;
@@ -7,9 +13,137 @@ class TrackOrderScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final order = context.read<OrdersCubit>().state.orders
+        .where((o) => o.id == orderId)
+        .firstOrNull;
+
     return Scaffold(
-      appBar: AppBar(title: const Text('Track Order')),
-      body: Center(child: Text('Tracking \$orderId')),
+      appBar: AppBar(
+        title: const Text(AppStrings.trackOrder),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios, size: 20),
+          onPressed: () => context.pop(),
+        ),
+      ),
+      body: order == null
+          ? const Center(child: Text('Order not found'))
+          : Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    order.orderNumber,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    order.date,
+                    style: const TextStyle(
+                      fontSize: 13,
+                      color: AppColors.textHint,
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+                  // Timeline
+                  ...List.generate(order.trackingSteps.length, (index) {
+                    final step = order.trackingSteps[index];
+                    final isLast = index == order.trackingSteps.length - 1;
+                    return _TimelineStep(
+                      step: step,
+                      isLast: isLast,
+                    );
+                  }),
+                ],
+              ),
+            ),
+    );
+  }
+}
+
+class _TimelineStep extends StatelessWidget {
+  final TrackingStep step;
+  final bool isLast;
+
+  const _TimelineStep({required this.step, required this.isLast});
+
+  @override
+  Widget build(BuildContext context) {
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Dot + line
+          Column(
+            children: [
+              Container(
+                width: 20,
+                height: 20,
+                decoration: BoxDecoration(
+                  color: step.isCompleted
+                      ? AppColors.primary
+                      : AppColors.divider,
+                  shape: BoxShape.circle,
+                ),
+                child: step.isCompleted
+                    ? const Icon(Icons.check, size: 12, color: AppColors.white)
+                    : null,
+              ),
+              if (!isLast)
+                Expanded(
+                  child: Container(
+                    width: 2,
+                    constraints: const BoxConstraints(minHeight: 40),
+                    color: step.isCompleted
+                        ? AppColors.primary
+                        : AppColors.divider,
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(width: 16),
+          // Content
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    step.title,
+                    style: TextStyle(
+                      fontWeight: FontWeight.w600,
+                      fontSize: 15,
+                      color: step.isCompleted
+                          ? AppColors.textPrimary
+                          : AppColors.textHint,
+                    ),
+                  ),
+                  if (step.subtitle != null)
+                    Text(
+                      step.subtitle!,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        color: AppColors.textSecondary,
+                      ),
+                    ),
+                  if (step.date != null)
+                    Text(
+                      step.date!,
+                      style: const TextStyle(
+                        fontSize: 11,
+                        color: AppColors.textHint,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/profile/presentation/screens/edit_profile_screen.dart
+++ b/lib/features/profile/presentation/screens/edit_profile_screen.dart
@@ -1,13 +1,127 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/app_strings.dart';
+import '../../../../core/utils/validators.dart';
+import '../../../../core/widgets/app_button.dart';
+import '../../../../core/widgets/app_text_field.dart';
 
-class EditProfileScreen extends StatelessWidget {
+class EditProfileScreen extends StatefulWidget {
   const EditProfileScreen({super.key});
+
+  @override
+  State<EditProfileScreen> createState() => _EditProfileScreenState();
+}
+
+class _EditProfileScreenState extends State<EditProfileScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController(text: 'John Doe');
+  final _emailController = TextEditingController(text: 'john.doe@email.com');
+  final _phoneController = TextEditingController(text: '(415) 555-0128');
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _emailController.dispose();
+    _phoneController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Edit Profile')),
-      body: const Center(child: Text('Edit Profile')),
+      appBar: AppBar(
+        title: const Text(AppStrings.editProfile),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios, size: 20),
+          onPressed: () => context.pop(),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              // Avatar
+              Stack(
+                children: [
+                  const CircleAvatar(
+                    radius: 50,
+                    backgroundColor: AppColors.primaryLight,
+                    child: Icon(Icons.person, size: 50, color: AppColors.primaryDark),
+                  ),
+                  Positioned(
+                    bottom: 0,
+                    right: 0,
+                    child: GestureDetector(
+                      onTap: () {},
+                      child: Container(
+                        width: 32,
+                        height: 32,
+                        decoration: const BoxDecoration(
+                          color: AppColors.primary,
+                          shape: BoxShape.circle,
+                        ),
+                        child: const Icon(
+                          Icons.camera_alt,
+                          size: 16,
+                          color: AppColors.white,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 32),
+              AppTextField(
+                controller: _nameController,
+                label: AppStrings.fullName,
+                hint: 'Enter your full name',
+                validator: (v) => Validators.required(v, 'Full name'),
+                prefixIcon: const Icon(Icons.person_outlined, size: 20),
+                textInputAction: TextInputAction.next,
+              ),
+              const SizedBox(height: 16),
+              AppTextField(
+                controller: _emailController,
+                label: AppStrings.email,
+                hint: 'Enter your email',
+                keyboardType: TextInputType.emailAddress,
+                validator: Validators.email,
+                prefixIcon: const Icon(Icons.email_outlined, size: 20),
+                textInputAction: TextInputAction.next,
+              ),
+              const SizedBox(height: 16),
+              AppTextField(
+                controller: _phoneController,
+                label: AppStrings.phoneNumber,
+                hint: 'Enter phone number',
+                keyboardType: TextInputType.phone,
+                validator: Validators.phone,
+                prefixIcon: const Icon(Icons.phone_outlined, size: 20),
+                textInputAction: TextInputAction.done,
+              ),
+              const SizedBox(height: 32),
+              AppButton(
+                text: AppStrings.save,
+                onPressed: () {
+                  if (_formKey.currentState?.validate() ?? false) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        content: Text('Profile updated!'),
+                        backgroundColor: AppColors.primary,
+                        behavior: SnackBarBehavior.floating,
+                      ),
+                    );
+                    context.pop();
+                  }
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/profile/presentation/screens/notification_settings_screen.dart
+++ b/lib/features/profile/presentation/screens/notification_settings_screen.dart
@@ -1,13 +1,107 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/app_strings.dart';
 
-class NotificationSettingsScreen extends StatelessWidget {
+class NotificationSettingsScreen extends StatefulWidget {
   const NotificationSettingsScreen({super.key});
+
+  @override
+  State<NotificationSettingsScreen> createState() =>
+      _NotificationSettingsScreenState();
+}
+
+class _NotificationSettingsScreenState
+    extends State<NotificationSettingsScreen> {
+  bool _orderUpdates = true;
+  bool _promotions = true;
+  bool _newProducts = false;
+  bool _priceAlerts = true;
+  bool _deliveryUpdates = true;
+  bool _newsletter = false;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Notifications')),
-      body: const Center(child: Text('Notifications')),
+      appBar: AppBar(
+        title: const Text(AppStrings.notifications),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios, size: 20),
+          onPressed: () => context.pop(),
+        ),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _buildToggle(
+            'Order Updates',
+            'Get notified about order status changes',
+            _orderUpdates,
+            (v) => setState(() => _orderUpdates = v),
+          ),
+          _buildToggle(
+            'Promotions',
+            'Receive promotional offers and deals',
+            _promotions,
+            (v) => setState(() => _promotions = v),
+          ),
+          _buildToggle(
+            'New Products',
+            'Be the first to know about new arrivals',
+            _newProducts,
+            (v) => setState(() => _newProducts = v),
+          ),
+          _buildToggle(
+            'Price Alerts',
+            'Get notified when prices drop',
+            _priceAlerts,
+            (v) => setState(() => _priceAlerts = v),
+          ),
+          _buildToggle(
+            'Delivery Updates',
+            'Real-time delivery tracking notifications',
+            _deliveryUpdates,
+            (v) => setState(() => _deliveryUpdates = v),
+          ),
+          _buildToggle(
+            'Newsletter',
+            'Weekly newsletter with recipes and tips',
+            _newsletter,
+            (v) => setState(() => _newsletter = v),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildToggle(
+    String title,
+    String subtitle,
+    bool value,
+    ValueChanged<bool> onChanged,
+  ) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: SwitchListTile(
+        title: Text(
+          title,
+          style: const TextStyle(
+            fontWeight: FontWeight.w500,
+            fontSize: 15,
+          ),
+        ),
+        subtitle: Text(
+          subtitle,
+          style: const TextStyle(
+            fontSize: 12,
+            color: AppColors.textSecondary,
+          ),
+        ),
+        value: value,
+        onChanged: onChanged,
+        activeColor: AppColors.primary,
+        contentPadding: EdgeInsets.zero,
+      ),
     );
   }
 }

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -1,4 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/app_strings.dart';
+import '../../../auth/presentation/cubit/auth_cubit.dart';
 
 class ProfileScreen extends StatelessWidget {
   const ProfileScreen({super.key});
@@ -6,8 +11,146 @@ class ProfileScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('My Account')),
-      body: const Center(child: Text('My Account')),
+      appBar: AppBar(title: const Text(AppStrings.myAccount)),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            // Avatar + name
+            const CircleAvatar(
+              radius: 40,
+              backgroundColor: AppColors.primaryLight,
+              child: Icon(Icons.person, size: 40, color: AppColors.primaryDark),
+            ),
+            const SizedBox(height: 12),
+            const Text(
+              'John Doe',
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            const SizedBox(height: 4),
+            const Text(
+              'john.doe@email.com',
+              style: TextStyle(
+                fontSize: 14,
+                color: AppColors.textSecondary,
+              ),
+            ),
+            const SizedBox(height: 24),
+            // Menu items
+            _MenuItem(
+              icon: Icons.shopping_bag_outlined,
+              title: AppStrings.myOrders,
+              onTap: () => context.push('/my-orders'),
+            ),
+            _MenuItem(
+              icon: Icons.location_on_outlined,
+              title: AppStrings.shippingAddresses,
+              onTap: () {},
+            ),
+            _MenuItem(
+              icon: Icons.payment_outlined,
+              title: AppStrings.paymentMethods,
+              onTap: () {},
+            ),
+            _MenuItem(
+              icon: Icons.settings_outlined,
+              title: AppStrings.settings,
+              onTap: () => context.push('/edit-profile'),
+            ),
+            _MenuItem(
+              icon: Icons.notifications_outlined,
+              title: AppStrings.notifications,
+              onTap: () => context.push('/notification-settings'),
+            ),
+            const SizedBox(height: 8),
+            _MenuItem(
+              icon: Icons.logout,
+              title: AppStrings.logout,
+              isDestructive: true,
+              onTap: () {
+                showDialog(
+                  context: context,
+                  builder: (ctx) => AlertDialog(
+                    title: const Text('Logout'),
+                    content: const Text('Are you sure you want to logout?'),
+                    actions: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(ctx),
+                        child: const Text('Cancel'),
+                      ),
+                      TextButton(
+                        onPressed: () {
+                          Navigator.pop(ctx);
+                          context.read<AuthCubit>().logout();
+                          context.go('/sign-in');
+                        },
+                        child: const Text(
+                          'Logout',
+                          style: TextStyle(color: AppColors.error),
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MenuItem extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final VoidCallback onTap;
+  final bool isDestructive;
+
+  const _MenuItem({
+    required this.icon,
+    required this.title,
+    required this.onTap,
+    this.isDestructive = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        margin: const EdgeInsets.only(bottom: 4),
+        child: Row(
+          children: [
+            Icon(
+              icon,
+              size: 22,
+              color: isDestructive ? AppColors.error : AppColors.textSecondary,
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Text(
+                title,
+                style: TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w500,
+                  color: isDestructive ? AppColors.error : AppColors.textPrimary,
+                ),
+              ),
+            ),
+            if (!isDestructive)
+              const Icon(
+                Icons.arrow_forward_ios,
+                size: 16,
+                color: AppColors.textHint,
+              ),
+          ],
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- My Orders with Active/Completed/Cancelled tabs, order cards with status badges, item previews, and action buttons (Track/Re-Order/Rate)
- Order Detail with items list, order summary, shipping address
- Track Order with timeline stepper showing completed/pending steps
- Profile screen with avatar, menu items, and logout with confirmation dialog
- Edit Profile with avatar upload placeholder, name/email/phone validation
- Notification Settings with 6 toggle switches
- Full Clean Architecture: OrderModel, OrderItemModel, TrackingStep, mock datasource, repository, OrdersCubit

## Test plan
- [ ] My Orders shows Active tab by default with 2 orders
- [ ] Switching to Completed/Cancelled tabs filters orders
- [ ] Order cards show status badge, item previews, and price
- [ ] Tapping order navigates to detail screen
- [ ] Track Order shows timeline with completed steps in green
- [ ] Profile shows avatar, name, email, and menu items
- [ ] My Orders menu item navigates to orders screen
- [ ] Edit Profile validates and saves with snackbar
- [ ] Notification toggles switch on/off
- [ ] Logout shows confirmation dialog, clears session, navigates to sign-in

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)