### PR TITLE
feat: wire cart & wishlist functionality across all screens

### DIFF
--- a/lib/core/widgets/main_shell.dart
+++ b/lib/core/widgets/main_shell.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import '../constants/app_colors.dart';
+import '../di/injection.dart';
+import '../../features/cart/presentation/cubit/cart_cubit.dart';
+import '../../features/cart/presentation/cubit/cart_state.dart';
 
 class MainShell extends StatelessWidget {
   final Widget child;
@@ -33,71 +37,79 @@ class MainShell extends StatelessWidget {
   Widget build(BuildContext context) {
     final currentIndex = _getCurrentIndex(context);
 
-    return Scaffold(
-      body: child,
-      bottomNavigationBar: Container(
-        decoration: BoxDecoration(
-          color: AppColors.white,
-          boxShadow: [
-            BoxShadow(
-              color: AppColors.shadow.withValues(alpha: 0.1),
-              blurRadius: 10,
-              offset: const Offset(0, -2),
-            ),
-          ],
-        ),
-        child: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
-              children: [
-                _NavItem(
-                  icon: Icons.home_outlined,
-                  activeIcon: Icons.home,
-                  label: 'Home',
-                  isActive: currentIndex == 0,
-                  onTap: () => _onTap(context, 0),
-                ),
-                _NavItem(
-                  icon: Icons.favorite_outline,
-                  activeIcon: Icons.favorite,
-                  label: 'Wishlist',
-                  isActive: currentIndex == 1,
-                  onTap: () => _onTap(context, 1),
-                ),
-                // Center FAB
-                GestureDetector(
-                  onTap: () => context.push('/categories'),
-                  child: Container(
-                    width: 56,
-                    height: 56,
-                    decoration: const BoxDecoration(
-                      color: AppColors.primaryDark,
-                      shape: BoxShape.circle,
-                    ),
-                    child: const Icon(
-                      Icons.grid_view_rounded,
-                      color: AppColors.white,
-                      size: 28,
+    return BlocProvider.value(
+      value: getIt<CartCubit>(),
+      child: Scaffold(
+        body: child,
+        bottomNavigationBar: Container(
+          decoration: BoxDecoration(
+            color: AppColors.white,
+            boxShadow: [
+              BoxShadow(
+                color: AppColors.shadow.withValues(alpha: 0.1),
+                blurRadius: 10,
+                offset: const Offset(0, -2),
+              ),
+            ],
+          ),
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  _NavItem(
+                    icon: Icons.home_outlined,
+                    activeIcon: Icons.home,
+                    label: 'Home',
+                    isActive: currentIndex == 0,
+                    onTap: () => _onTap(context, 0),
+                  ),
+                  _NavItem(
+                    icon: Icons.favorite_outline,
+                    activeIcon: Icons.favorite,
+                    label: 'Wishlist',
+                    isActive: currentIndex == 1,
+                    onTap: () => _onTap(context, 1),
+                  ),
+                  // Center FAB
+                  GestureDetector(
+                    onTap: () => context.push('/categories'),
+                    child: Container(
+                      width: 56,
+                      height: 56,
+                      decoration: const BoxDecoration(
+                        color: AppColors.primaryDark,
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(
+                        Icons.grid_view_rounded,
+                        color: AppColors.white,
+                        size: 28,
+                      ),
                     ),
                   ),
-                ),
-                _NavItem(
-                  icon: Icons.shopping_cart_outlined,
-                  activeIcon: Icons.shopping_cart,
-                  label: 'Cart',
-                  isActive: currentIndex == 3,
-                  onTap: () => _onTap(context, 3),
-                ),
-                _NavItem(
-                  icon: Icons.person_outline,
-                  activeIcon: Icons.person,
-                  label: 'Profile',
-                  isActive: currentIndex == 4,
-                  onTap: () => _onTap(context, 4),
-                ),
-              ],
+                  BlocBuilder<CartCubit, CartState>(
+                    builder: (context, cartState) {
+                      return _NavItem(
+                        icon: Icons.shopping_cart_outlined,
+                        activeIcon: Icons.shopping_cart,
+                        label: 'Cart',
+                        isActive: currentIndex == 3,
+                        onTap: () => _onTap(context, 3),
+                        badgeCount: cartState.itemCount,
+                      );
+                    },
+                  ),
+                  _NavItem(
+                    icon: Icons.person_outline,
+                    activeIcon: Icons.person,
+                    label: 'Profile',
+                    isActive: currentIndex == 4,
+                    onTap: () => _onTap(context, 4),
+                  ),
+                ],
+              ),
             ),
           ),
         ),
@@ -112,6 +124,7 @@ class _NavItem extends StatelessWidget {
   final String label;
   final bool isActive;
   final VoidCallback onTap;
+  final int badgeCount;
 
   const _NavItem({
     required this.icon,
@@ -119,6 +132,7 @@ class _NavItem extends StatelessWidget {
     required this.label,
     required this.isActive,
     required this.onTap,
+    this.badgeCount = 0,
   });
 
   @override
@@ -131,11 +145,26 @@ class _NavItem extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(
-              isActive ? activeIcon : icon,
-              color: isActive ? AppColors.primary : AppColors.textHint,
-              size: 24,
-            ),
+            badgeCount > 0
+                ? Badge(
+                    label: Text(
+                      '$badgeCount',
+                      style: const TextStyle(
+                        color: AppColors.white,
+                        fontSize: 10,
+                      ),
+                    ),
+                    child: Icon(
+                      isActive ? activeIcon : icon,
+                      color: isActive ? AppColors.primary : AppColors.textHint,
+                      size: 24,
+                    ),
+                  )
+                : Icon(
+                    isActive ? activeIcon : icon,
+                    color: isActive ? AppColors.primary : AppColors.textHint,
+                    size: 24,
+                  ),
             const SizedBox(height: 4),
             Text(
               label,

--- a/lib/core/widgets/product_card.dart
+++ b/lib/core/widgets/product_card.dart
@@ -190,7 +190,44 @@ class ProductCard extends StatelessWidget {
                             ),
                           ),
                         ],
+                        const Spacer(),
+                        if (onAddToCart != null)
+                          GestureDetector(
+                            onTap: onAddToCart,
+                            child: Container(
+                              padding: const EdgeInsets.all(4),
+                              decoration: BoxDecoration(
+                                color: AppColors.primary,
+                                borderRadius: BorderRadius.circular(6),
+                              ),
+                              child: const Icon(
+                                Icons.add_shopping_cart,
+                                color: AppColors.white,
+                                size: 16,
+                              ),
+                            ),
+                          ),
                       ],
+                    ),
+                  ] else if (onAddToCart != null) ...[
+                    const SizedBox(height: 4),
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: GestureDetector(
+                        onTap: onAddToCart,
+                        child: Container(
+                          padding: const EdgeInsets.all(4),
+                          decoration: BoxDecoration(
+                            color: AppColors.primary,
+                            borderRadius: BorderRadius.circular(6),
+                          ),
+                          child: const Icon(
+                            Icons.add_shopping_cart,
+                            color: AppColors.white,
+                            size: 16,
+                          ),
+                        ),
+                      ),
                     ),
                   ],
                 ],

--- a/lib/features/cart/data/datasources/cart_mock_datasource.dart
+++ b/lib/features/cart/data/datasources/cart_mock_datasource.dart
@@ -82,6 +82,18 @@ class CartMockDatasource {
     return List.from(_items);
   }
 
+  Future<void> addItem(CartItemModel item) async {
+    await Future.delayed(const Duration(milliseconds: 200));
+    final index = _items.indexWhere((i) => i.productId == item.productId);
+    if (index != -1) {
+      _items[index] = _items[index].copyWith(
+        quantity: _items[index].quantity + item.quantity,
+      );
+    } else {
+      _items.add(item);
+    }
+  }
+
   Future<void> updateQuantity(String id, int quantity) async {
     await Future.delayed(const Duration(milliseconds: 200));
     final index = _items.indexWhere((item) => item.id == id);

--- a/lib/features/cart/data/repositories/cart_repository_impl.dart
+++ b/lib/features/cart/data/repositories/cart_repository_impl.dart
@@ -21,6 +21,16 @@ class CartRepositoryImpl implements CartRepository {
   }
 
   @override
+  Future<Either<ApiException, void>> addItem(CartItemModel item) async {
+    try {
+      await _mockDatasource.addItem(item);
+      return const Right(null);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+
+  @override
   Future<Either<ApiException, void>> updateQuantity(
     String id,
     int quantity,

--- a/lib/features/cart/domain/repositories/cart_repository.dart
+++ b/lib/features/cart/domain/repositories/cart_repository.dart
@@ -5,6 +5,7 @@ import '../../data/models/address_model.dart';
 
 abstract class CartRepository {
   Future<Either<ApiException, List<CartItemModel>>> getCartItems();
+  Future<Either<ApiException, void>> addItem(CartItemModel item);
   Future<Either<ApiException, void>> updateQuantity(String id, int quantity);
   Future<Either<ApiException, void>> removeItem(String id);
   Future<Either<ApiException, double>> applyCoupon(String code);

--- a/lib/features/cart/presentation/cubit/cart_cubit.dart
+++ b/lib/features/cart/presentation/cubit/cart_cubit.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../data/models/cart_item_model.dart';
 import '../../domain/repositories/cart_repository.dart';
 import 'cart_state.dart';
 
@@ -6,6 +7,23 @@ class CartCubit extends Cubit<CartState> {
   final CartRepository _repository;
 
   CartCubit(this._repository) : super(const CartState());
+
+  Future<void> addItem(CartItemModel item) async {
+    final existing = state.items.where((i) => i.productId == item.productId);
+    List<CartItemModel> updatedItems;
+    if (existing.isNotEmpty) {
+      updatedItems = state.items.map((i) {
+        if (i.productId == item.productId) {
+          return i.copyWith(quantity: i.quantity + item.quantity);
+        }
+        return i;
+      }).toList();
+    } else {
+      updatedItems = [...state.items, item];
+    }
+    emit(state.copyWith(items: updatedItems, status: CartStatus.loaded));
+    await _repository.addItem(item);
+  }
 
   Future<void> loadCart() async {
     emit(state.copyWith(status: CartStatus.loading));

--- a/lib/features/categories/presentation/screens/product_list_screen.dart
+++ b/lib/features/categories/presentation/screens/product_list_screen.dart
@@ -2,8 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/constants/app_colors.dart';
+import '../../../../core/di/injection.dart';
 import '../../../../core/widgets/product_card.dart';
 import '../../../../core/widgets/loading_shimmer.dart';
+import '../../../cart/data/models/cart_item_model.dart';
+import '../../../cart/presentation/cubit/cart_cubit.dart';
+import '../../../home/data/models/product_model.dart';
+import '../../../wishlist/presentation/cubit/wishlist_cubit.dart';
 import '../cubit/product_list_cubit.dart';
 import '../cubit/product_list_state.dart';
 import '../widgets/empty_state_widget.dart';
@@ -42,6 +47,30 @@ class _ProductListScreenState extends State<ProductListScreen> {
         _scrollController.position.maxScrollExtent - 200) {
       context.read<ProductListCubit>().loadMore();
     }
+  }
+
+  void _addToCart(BuildContext context, ProductModel product) {
+    getIt<CartCubit>().addItem(
+      CartItemModel(
+        id: 'cart_${product.id}',
+        productId: product.id,
+        name: product.name,
+        imageUrl: product.imageUrl,
+        price: product.price,
+        originalPrice: product.originalPrice,
+        quantity: 1,
+        variant: product.unit,
+        storeName: product.storeName,
+      ),
+    );
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('${product.name} added to cart'),
+        backgroundColor: AppColors.primary,
+        behavior: SnackBarBehavior.floating,
+        duration: const Duration(seconds: 1),
+      ),
+    );
   }
 
   @override
@@ -185,6 +214,7 @@ class _ProductListScreenState extends State<ProductListScreen> {
             return const ProductCardShimmer();
           }
           final product = state.products[index];
+          final wishlistCubit = getIt<WishlistCubit>();
           return ProductCard(
             id: product.id,
             name: product.name,
@@ -194,9 +224,10 @@ class _ProductListScreenState extends State<ProductListScreen> {
             rating: product.rating,
             reviewCount: product.reviewCount,
             discountPercent: product.discountPercent,
+            isWishlisted: wishlistCubit.isWishlisted(product.id),
             onTap: () => context.push('/product/${product.id}'),
-            onAddToCart: () {},
-            onWishlistToggle: () {},
+            onAddToCart: () => _addToCart(context, product),
+            onWishlistToggle: () => wishlistCubit.toggleItem(product),
           );
         },
       );
@@ -215,6 +246,7 @@ class _ProductListScreenState extends State<ProductListScreen> {
           );
         }
         final product = state.products[index];
+        final wishlistCubit = getIt<WishlistCubit>();
         return Padding(
           padding: const EdgeInsets.only(bottom: 12),
           child: SizedBox(
@@ -228,9 +260,10 @@ class _ProductListScreenState extends State<ProductListScreen> {
               rating: product.rating,
               reviewCount: product.reviewCount,
               discountPercent: product.discountPercent,
+              isWishlisted: wishlistCubit.isWishlisted(product.id),
               onTap: () => context.push('/product/${product.id}'),
-              onAddToCart: () {},
-              onWishlistToggle: () {},
+              onAddToCart: () => _addToCart(context, product),
+              onWishlistToggle: () => wishlistCubit.toggleItem(product),
             ),
           ),
         );

--- a/lib/features/home/presentation/screens/home_screen.dart
+++ b/lib/features/home/presentation/screens/home_screen.dart
@@ -3,7 +3,11 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/constants/app_colors.dart';
 import '../../../../core/constants/app_strings.dart';
+import '../../../../core/di/injection.dart';
 import '../../../../core/widgets/product_card.dart';
+import '../../../cart/data/models/cart_item_model.dart';
+import '../../../cart/presentation/cubit/cart_cubit.dart';
+import '../../../wishlist/presentation/cubit/wishlist_cubit.dart';
 import '../../data/models/product_model.dart';
 import '../cubit/home_cubit.dart';
 import '../cubit/home_state.dart';
@@ -16,84 +20,90 @@ class HomeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: BlocBuilder<HomeCubit, HomeState>(
-          builder: (context, state) {
-            if (state.status == HomeStatus.loading ||
-                state.status == HomeStatus.initial) {
-              return const HomeShimmer();
-            }
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider.value(value: getIt<CartCubit>()),
+        BlocProvider.value(value: getIt<WishlistCubit>()),
+      ],
+      child: Scaffold(
+        body: SafeArea(
+          child: BlocBuilder<HomeCubit, HomeState>(
+            builder: (context, state) {
+              if (state.status == HomeStatus.loading ||
+                  state.status == HomeStatus.initial) {
+                return const HomeShimmer();
+              }
 
-            if (state.status == HomeStatus.error &&
-                state.banners.isEmpty) {
-              return _ErrorView(
-                message: state.errorMessage ?? 'Something went wrong',
-                onRetry: () => context.read<HomeCubit>().loadHome(),
-              );
-            }
+              if (state.status == HomeStatus.error &&
+                  state.banners.isEmpty) {
+                return _ErrorView(
+                  message: state.errorMessage ?? 'Something went wrong',
+                  onRetry: () => context.read<HomeCubit>().loadHome(),
+                );
+              }
 
-            return RefreshIndicator(
-              color: AppColors.primary,
-              onRefresh: () => context.read<HomeCubit>().refresh(),
-              child: SingleChildScrollView(
-                physics: const AlwaysScrollableScrollPhysics(),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    _buildTopBar(context),
-                    _buildSearchBar(context),
-                    const SizedBox(height: 20),
-                    BannerCarousel(banners: state.banners),
-                    const SizedBox(height: 20),
-                    _buildSectionHeader(
-                      context,
-                      AppStrings.categories,
-                      () => context.push('/categories'),
-                    ),
-                    const SizedBox(height: 12),
-                    CategoryScroll(
-                      categories: state.categories,
-                      onCategoryTap: (category) {
-                        context.push(
-                          '/products/${category.id}',
-                          extra: category.name,
-                        );
-                      },
-                    ),
-                    const SizedBox(height: 20),
-                    _buildSectionHeader(
-                      context,
-                      AppStrings.featuredProducts,
-                      () {},
-                    ),
-                    const SizedBox(height: 12),
-                    _buildHorizontalProductList(
-                      context,
-                      state.featuredProducts,
-                    ),
-                    const SizedBox(height: 20),
-                    _buildSectionHeader(
-                      context,
-                      AppStrings.bestSelling,
-                      () {},
-                    ),
-                    const SizedBox(height: 12),
-                    _buildProductGrid(context, state.bestSelling),
-                    const SizedBox(height: 20),
-                    _buildSectionHeader(
-                      context,
-                      AppStrings.popularProducts,
-                      () {},
-                    ),
-                    const SizedBox(height: 12),
-                    _buildProductGrid(context, state.popularProducts),
-                    const SizedBox(height: 24),
-                  ],
+              return RefreshIndicator(
+                color: AppColors.primary,
+                onRefresh: () => context.read<HomeCubit>().refresh(),
+                child: SingleChildScrollView(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _buildTopBar(context),
+                      _buildSearchBar(context),
+                      const SizedBox(height: 20),
+                      BannerCarousel(banners: state.banners),
+                      const SizedBox(height: 20),
+                      _buildSectionHeader(
+                        context,
+                        AppStrings.categories,
+                        () => context.push('/categories'),
+                      ),
+                      const SizedBox(height: 12),
+                      CategoryScroll(
+                        categories: state.categories,
+                        onCategoryTap: (category) {
+                          context.push(
+                            '/products/${category.id}',
+                            extra: category.name,
+                          );
+                        },
+                      ),
+                      const SizedBox(height: 20),
+                      _buildSectionHeader(
+                        context,
+                        AppStrings.featuredProducts,
+                        () {},
+                      ),
+                      const SizedBox(height: 12),
+                      _buildHorizontalProductList(
+                        context,
+                        state.featuredProducts,
+                      ),
+                      const SizedBox(height: 20),
+                      _buildSectionHeader(
+                        context,
+                        AppStrings.bestSelling,
+                        () {},
+                      ),
+                      const SizedBox(height: 12),
+                      _buildProductGrid(context, state.bestSelling),
+                      const SizedBox(height: 20),
+                      _buildSectionHeader(
+                        context,
+                        AppStrings.popularProducts,
+                        () {},
+                      ),
+                      const SizedBox(height: 12),
+                      _buildProductGrid(context, state.popularProducts),
+                      const SizedBox(height: 24),
+                    ],
+                  ),
                 ),
-              ),
-            );
-          },
+              );
+            },
+          ),
         ),
       ),
     );
@@ -208,36 +218,67 @@ class HomeScreen extends StatelessWidget {
     );
   }
 
+  void _addToCart(BuildContext context, ProductModel product) {
+    context.read<CartCubit>().addItem(
+          CartItemModel(
+            id: 'cart_${product.id}',
+            productId: product.id,
+            name: product.name,
+            imageUrl: product.imageUrl,
+            price: product.price,
+            originalPrice: product.originalPrice,
+            quantity: 1,
+            variant: product.unit,
+            storeName: product.storeName,
+          ),
+        );
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('${product.name} added to cart'),
+        backgroundColor: AppColors.primary,
+        behavior: SnackBarBehavior.floating,
+        duration: const Duration(seconds: 1),
+      ),
+    );
+  }
+
   Widget _buildHorizontalProductList(
     BuildContext context,
     List<ProductModel> products,
   ) {
     return SizedBox(
-      height: 230,
-      child: ListView.builder(
-        scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.symmetric(horizontal: 16),
-        itemCount: products.length,
-        itemBuilder: (context, index) {
-          final product = products[index];
-          return SizedBox(
-            width: 160,
-            child: Padding(
-              padding: const EdgeInsets.only(right: 12),
-              child: ProductCard(
-                id: product.id,
-                name: product.name,
-                imageUrl: product.imageUrl,
-                price: product.price,
-                originalPrice: product.originalPrice,
-                rating: product.rating,
-                reviewCount: product.reviewCount,
-                discountPercent: product.discountPercent,
-                onTap: () => context.push('/product/${product.id}'),
-                onAddToCart: () {},
-                onWishlistToggle: () {},
-              ),
-            ),
+      height: 250,
+      child: BlocBuilder<WishlistCubit, dynamic>(
+        builder: (context, _) {
+          final wishlistCubit = context.read<WishlistCubit>();
+          return ListView.builder(
+            scrollDirection: Axis.horizontal,
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            itemCount: products.length,
+            itemBuilder: (context, index) {
+              final product = products[index];
+              return SizedBox(
+                width: 160,
+                child: Padding(
+                  padding: const EdgeInsets.only(right: 12),
+                  child: ProductCard(
+                    id: product.id,
+                    name: product.name,
+                    imageUrl: product.imageUrl,
+                    price: product.price,
+                    originalPrice: product.originalPrice,
+                    rating: product.rating,
+                    reviewCount: product.reviewCount,
+                    discountPercent: product.discountPercent,
+                    isWishlisted: wishlistCubit.isWishlisted(product.id),
+                    onTap: () => context.push('/product/${product.id}'),
+                    onAddToCart: () => _addToCart(context, product),
+                    onWishlistToggle: () =>
+                        wishlistCubit.toggleItem(product),
+                  ),
+                ),
+              );
+            },
           );
         },
       ),
@@ -248,35 +289,42 @@ class HomeScreen extends StatelessWidget {
     BuildContext context,
     List<ProductModel> products,
   ) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16),
-      child: GridView.builder(
-        shrinkWrap: true,
-        physics: const NeverScrollableScrollPhysics(),
-        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: 2,
-          childAspectRatio: 0.68,
-          crossAxisSpacing: 12,
-          mainAxisSpacing: 12,
-        ),
-        itemCount: products.length,
-        itemBuilder: (context, index) {
-          final product = products[index];
-          return ProductCard(
-            id: product.id,
-            name: product.name,
-            imageUrl: product.imageUrl,
-            price: product.price,
-            originalPrice: product.originalPrice,
-            rating: product.rating,
-            reviewCount: product.reviewCount,
-            discountPercent: product.discountPercent,
-            onTap: () => context.push('/product/${product.id}'),
-            onAddToCart: () {},
-            onWishlistToggle: () {},
-          );
-        },
-      ),
+    return BlocBuilder<WishlistCubit, dynamic>(
+      builder: (context, _) {
+        final wishlistCubit = context.read<WishlistCubit>();
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: GridView.builder(
+            shrinkWrap: true,
+            physics: const NeverScrollableScrollPhysics(),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              childAspectRatio: 0.62,
+              crossAxisSpacing: 12,
+              mainAxisSpacing: 12,
+            ),
+            itemCount: products.length,
+            itemBuilder: (context, index) {
+              final product = products[index];
+              return ProductCard(
+                id: product.id,
+                name: product.name,
+                imageUrl: product.imageUrl,
+                price: product.price,
+                originalPrice: product.originalPrice,
+                rating: product.rating,
+                reviewCount: product.reviewCount,
+                discountPercent: product.discountPercent,
+                isWishlisted: wishlistCubit.isWishlisted(product.id),
+                onTap: () => context.push('/product/${product.id}'),
+                onAddToCart: () => _addToCart(context, product),
+                onWishlistToggle: () =>
+                    wishlistCubit.toggleItem(product),
+              );
+            },
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/product_detail/presentation/screens/product_detail_screen.dart
+++ b/lib/features/product_detail/presentation/screens/product_detail_screen.dart
@@ -3,10 +3,15 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import '../../../../core/constants/app_colors.dart';
 import '../../../../core/constants/app_strings.dart';
+import '../../../../core/di/injection.dart';
 import '../../../../core/utils/extensions.dart';
 import '../../../../core/widgets/app_button.dart';
 import '../../../../core/widgets/loading_shimmer.dart';
 import '../../../../core/widgets/product_card.dart';
+import '../../../cart/data/models/cart_item_model.dart';
+import '../../../cart/presentation/cubit/cart_cubit.dart';
+import '../../../home/data/models/product_model.dart';
+import '../../../wishlist/presentation/cubit/wishlist_cubit.dart';
 import '../cubit/product_detail_cubit.dart';
 import '../cubit/product_detail_state.dart';
 import '../widgets/product_image_gallery.dart';
@@ -33,11 +38,33 @@ class ProductDetailScreen extends StatelessWidget {
             actions: [
               IconButton(
                 icon: Icon(
-                  state.isWishlisted ? Icons.favorite : Icons.favorite_border,
-                  color: state.isWishlisted ? AppColors.error : null,
+                  getIt<WishlistCubit>().isWishlisted(productId)
+                      ? Icons.favorite
+                      : Icons.favorite_border,
+                  color: getIt<WishlistCubit>().isWishlisted(productId)
+                      ? AppColors.error
+                      : null,
                 ),
-                onPressed: () =>
-                    context.read<ProductDetailCubit>().toggleWishlist(),
+                onPressed: () {
+                  final product = state.product;
+                  if (product != null) {
+                    getIt<WishlistCubit>().toggleItem(
+                      ProductModel(
+                        id: product.id,
+                        name: product.name,
+                        imageUrl: product.imageUrl,
+                        price: product.price,
+                        originalPrice: product.originalPrice,
+                        rating: product.rating,
+                        reviewCount: product.reviewCount,
+                        discountPercent: product.discountPercent,
+                        unit: product.unit,
+                        storeName: product.storeName,
+                      ),
+                    );
+                    context.read<ProductDetailCubit>().toggleWishlist();
+                  }
+                },
               ),
               IconButton(
                 icon: const Icon(Icons.share_outlined),
@@ -388,8 +415,33 @@ class ProductDetailScreen extends StatelessWidget {
                         rating: related.rating,
                         reviewCount: related.reviewCount,
                         discountPercent: related.discountPercent,
+                        isWishlisted: getIt<WishlistCubit>().isWishlisted(related.id),
                         onTap: () =>
                             context.push('/product/${related.id}'),
+                        onAddToCart: () {
+                          getIt<CartCubit>().addItem(
+                            CartItemModel(
+                              id: 'cart_${related.id}',
+                              productId: related.id,
+                              name: related.name,
+                              imageUrl: related.imageUrl,
+                              price: related.price,
+                              originalPrice: related.originalPrice,
+                              quantity: 1,
+                              storeName: related.storeName,
+                            ),
+                          );
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text('${related.name} added to cart'),
+                              backgroundColor: AppColors.primary,
+                              behavior: SnackBarBehavior.floating,
+                              duration: const Duration(seconds: 1),
+                            ),
+                          );
+                        },
+                        onWishlistToggle: () =>
+                            getIt<WishlistCubit>().toggleItem(related),
                       ),
                     ),
                   );
@@ -419,13 +471,29 @@ class ProductDetailScreen extends StatelessWidget {
         child: AppButton(
           text: AppStrings.addToCart,
           onPressed: () {
+            final product = state.product!;
+            getIt<CartCubit>().addItem(
+              CartItemModel(
+                id: 'cart_${product.id}_${DateTime.now().millisecondsSinceEpoch}',
+                productId: product.id,
+                name: product.name,
+                imageUrl: product.imageUrl,
+                price: product.price,
+                originalPrice: product.originalPrice,
+                quantity: state.quantity,
+                variant: state.selectedVariant,
+                storeName: product.storeName,
+                storeId: product.storeId,
+              ),
+            );
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
                 content: Text(
-                  '${state.quantity}x ${state.product!.name} added to cart',
+                  '${state.quantity}x ${product.name} added to cart',
                 ),
                 backgroundColor: AppColors.primary,
                 behavior: SnackBarBehavior.floating,
+                duration: const Duration(seconds: 1),
               ),
             );
           },

--- a/lib/features/wishlist/data/datasources/wishlist_mock_datasource.dart
+++ b/lib/features/wishlist/data/datasources/wishlist_mock_datasource.dart
@@ -96,4 +96,15 @@ class WishlistMockDatasource {
     await Future.delayed(const Duration(milliseconds: 200));
     _items.removeWhere((item) => item.id == productId);
   }
+
+  bool isWishlisted(String productId) {
+    return _items.any((item) => item.id == productId);
+  }
+
+  Future<void> addItem(ProductModel product) async {
+    await Future.delayed(const Duration(milliseconds: 200));
+    if (!_items.any((item) => item.id == product.id)) {
+      _items.add(product);
+    }
+  }
 }

--- a/lib/features/wishlist/data/repositories/wishlist_repository_impl.dart
+++ b/lib/features/wishlist/data/repositories/wishlist_repository_impl.dart
@@ -31,4 +31,19 @@ class WishlistRepositoryImpl implements WishlistRepository {
       return Left(e);
     }
   }
+
+  @override
+  Future<Either<ApiException, void>> addItem(ProductModel product) async {
+    try {
+      await _mockDatasource.addItem(product);
+      return const Right(null);
+    } on ApiException catch (e) {
+      return Left(e);
+    }
+  }
+
+  @override
+  bool isWishlisted(String productId) {
+    return _mockDatasource.isWishlisted(productId);
+  }
 }

--- a/lib/features/wishlist/domain/repositories/wishlist_repository.dart
+++ b/lib/features/wishlist/domain/repositories/wishlist_repository.dart
@@ -8,4 +8,6 @@ abstract class WishlistRepository {
     String? category,
   });
   Future<Either<ApiException, void>> removeItem(String productId);
+  Future<Either<ApiException, void>> addItem(ProductModel product);
+  bool isWishlisted(String productId);
 }

--- a/lib/features/wishlist/presentation/cubit/wishlist_cubit.dart
+++ b/lib/features/wishlist/presentation/cubit/wishlist_cubit.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../home/data/models/product_model.dart';
 import '../../domain/repositories/wishlist_repository.dart';
 import 'wishlist_state.dart';
 
@@ -6,6 +7,20 @@ class WishlistCubit extends Cubit<WishlistState> {
   final WishlistRepository _repository;
 
   WishlistCubit(this._repository) : super(const WishlistState());
+
+  bool isWishlisted(String productId) {
+    return state.items.any((item) => item.id == productId);
+  }
+
+  Future<void> toggleItem(ProductModel product) async {
+    if (isWishlisted(product.id)) {
+      await removeItem(product.id);
+    } else {
+      final updatedItems = [...state.items, product];
+      emit(state.copyWith(items: updatedItems));
+      await _repository.addItem(product);
+    }
+  }
 
   Future<void> loadWishlist() async {
     emit(state.copyWith(status: WishlistStatus.loading));

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,8 @@ import 'core/theme/app_theme.dart';
 import 'core/router/app_router.dart';
 import 'core/di/injection.dart';
 import 'features/auth/presentation/cubit/auth_cubit.dart';
+import 'features/cart/presentation/cubit/cart_cubit.dart';
+import 'features/wishlist/presentation/cubit/wishlist_cubit.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -25,6 +27,10 @@ void main() async {
 
   // Initialize dependencies
   await configureDependencies();
+
+  // Pre-load cart and wishlist so badge counts are ready
+  getIt<CartCubit>().loadCart();
+  getIt<WishlistCubit>().loadWishlist();
 
   runApp(const EGroceryApp());
 }


### PR DESCRIPTION
## Summary
- **Add to cart working** — tapping add-to-cart button on product cards or "Add to Cart" on product detail now actually adds items to the cart via CartCubit
- **Cart badge count** — bottom nav cart icon shows item count badge that updates in real-time
- **Add-to-cart button on product cards** — green cart icon visible on every product card
- **Wishlist toggle working everywhere** — heart button on product cards (home, categories, product detail) now toggles wishlist state via WishlistCubit
- **Cross-screen sync** — product detail wishlist button syncs with WishlistCubit, not just local state

## Changes (14 files)

### Cart layer
- `CartMockDatasource` — added `addItem()` (increments qty if product exists)
- `CartRepository` / `CartRepositoryImpl` — added `addItem()` contract + impl
- `CartCubit` — added `addItem()` with optimistic UI update

### Wishlist layer
- `WishlistMockDatasource` — added `addItem()`, `isWishlisted()`
- `WishlistRepository` / `WishlistRepositoryImpl` — added `addItem()`, `isWishlisted()`
- `WishlistCubit` — added `toggleItem()`, `isWishlisted()`

### UI wiring
- `ProductCard` — added visible add-to-cart icon button
- `MainShell` — cart icon now shows badge count via `BlocBuilder<CartCubit>`
- `HomeScreen` — wired `onAddToCart` and `onWishlistToggle` callbacks
- `ProductListScreen` — wired `onAddToCart` and `onWishlistToggle` callbacks
- `ProductDetailScreen` — "Add to Cart" button calls `CartCubit.addItem()`, wishlist button calls `WishlistCubit.toggleItem()`
- `main.dart` — pre-loads cart & wishlist on startup

## Test plan
- [ ] Tap add-to-cart on home screen product card → cart badge increments, snackbar shows
- [ ] Tap add-to-cart on product detail → item added with correct quantity & variant
- [ ] Navigate to cart → see all added items
- [ ] Tap wishlist heart on product card → fills red, appears in wishlist screen
- [ ] Tap again → unfills, removed from wishlist
- [ ] Cart badge persists across tab navigation

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)